### PR TITLE
Make sentire AI-agent-friendly

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,132 @@
+# Sentire — Agent Context
+
+Sentire is a read-only CLI for the Sentry API. It retrieves issues, events, projects, and organization data from Sentry.
+
+## Authentication
+
+Set `SENTRY_API_TOKEN` before using any command:
+
+```
+export SENTRY_API_TOKEN=<your-token>
+```
+
+Missing token returns exit code 2 with `auth_missing` error code.
+
+## Command Reference
+
+### Issues & Events
+
+```bash
+# List unresolved issues (default query: is:unresolved, high/medium priority)
+sentire events list-issues <org-slug>
+sentire events list-issues <org-slug> --query "is:unresolved"
+
+# Get a single issue
+sentire events get-issue <org-slug> <issue-id>
+
+# Get the recommended event for an issue (full stack trace)
+sentire events get-issue-event <org-slug> <issue-id> recommended
+
+# List events for an issue
+sentire events list-issue <org-slug> <issue-id>
+
+# List events for a project
+sentire events list-project <org-slug> <project-slug>
+
+# Get a specific event
+sentire events get-event <org-slug> <project-slug> <event-id>
+```
+
+### Inspect (shortcut)
+
+Parse a Sentry URL and fetch the recommended event:
+
+```bash
+sentire inspect "https://myorg.sentry.io/issues/123456789/"
+```
+
+### Projects
+
+```bash
+sentire projects list
+sentire projects get <org-slug> <project-slug>
+sentire org list-projects <org-slug>
+```
+
+### Organization Stats
+
+```bash
+sentire org stats <org-slug> --period 7d
+```
+
+## Output Control
+
+### Format
+
+Default output is JSON. Available formats: `json`, `ndjson`, `table`, `text`, `markdown`.
+
+```bash
+sentire events list-issues myorg --format ndjson
+```
+
+### Field Filtering
+
+Use `--fields` to limit JSON output to specific fields — reduces token usage:
+
+```bash
+sentire events list-issues myorg --fields id,title,status,lastSeen
+sentire events get-issue myorg 12345 --fields id,title,count,userCount
+```
+
+### Pagination
+
+Use `--all` to fetch all pages:
+
+```bash
+sentire events list-issues myorg --all
+```
+
+## Schema Introspection
+
+Use `describe` to discover commands and output fields as JSON:
+
+```bash
+# List all commands with args, flags, and output fields
+sentire describe
+
+# Describe a specific command
+sentire describe events list-issues
+```
+
+## Error Handling
+
+Errors are structured JSON when using `--format json` (default):
+
+```json
+{"error": "message", "code": "error_code"}
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General/unknown error |
+| 2 | Authentication error (missing or invalid token) |
+| 3 | API error (4xx/5xx from Sentry) |
+| 4 | Invalid input (bad slug, ID, URL, or format) |
+
+### Error Codes
+
+- `auth_missing` — SENTRY_API_TOKEN not set
+- `api_error` — Sentry API returned an error
+- `invalid_input` — Bad argument (malformed slug, ID, or URL)
+- `invalid_format` — Unsupported output format
+
+## Tips for AI Agents
+
+1. Use `sentire describe` to discover available commands and their output schemas
+2. Use `--fields` to request only the fields you need — Sentry events can be very large
+3. Use `--format ndjson` for streaming line-by-line processing
+4. Check exit codes for error classification instead of parsing messages
+5. All output goes to stdout, errors go to stderr

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed context_content.md
+var contextContent string
+
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Print agent-friendly context and usage guide",
+	Long:  "Output the CONTEXT.md file with guidance for AI agents on how to use sentire effectively",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Print(contextContent)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(contextCmd)
+}

--- a/internal/cli/context_content.md
+++ b/internal/cli/context_content.md
@@ -1,0 +1,132 @@
+# Sentire — Agent Context
+
+Sentire is a read-only CLI for the Sentry API. It retrieves issues, events, projects, and organization data from Sentry.
+
+## Authentication
+
+Set `SENTRY_API_TOKEN` before using any command:
+
+```
+export SENTRY_API_TOKEN=<your-token>
+```
+
+Missing token returns exit code 2 with `auth_missing` error code.
+
+## Command Reference
+
+### Issues & Events
+
+```bash
+# List unresolved issues (default query: is:unresolved, high/medium priority)
+sentire events list-issues <org-slug>
+sentire events list-issues <org-slug> --query "is:unresolved"
+
+# Get a single issue
+sentire events get-issue <org-slug> <issue-id>
+
+# Get the recommended event for an issue (full stack trace)
+sentire events get-issue-event <org-slug> <issue-id> recommended
+
+# List events for an issue
+sentire events list-issue <org-slug> <issue-id>
+
+# List events for a project
+sentire events list-project <org-slug> <project-slug>
+
+# Get a specific event
+sentire events get-event <org-slug> <project-slug> <event-id>
+```
+
+### Inspect (shortcut)
+
+Parse a Sentry URL and fetch the recommended event:
+
+```bash
+sentire inspect "https://myorg.sentry.io/issues/123456789/"
+```
+
+### Projects
+
+```bash
+sentire projects list
+sentire projects get <org-slug> <project-slug>
+sentire org list-projects <org-slug>
+```
+
+### Organization Stats
+
+```bash
+sentire org stats <org-slug> --period 7d
+```
+
+## Output Control
+
+### Format
+
+Default output is JSON. Available formats: `json`, `ndjson`, `table`, `text`, `markdown`.
+
+```bash
+sentire events list-issues myorg --format ndjson
+```
+
+### Field Filtering
+
+Use `--fields` to limit JSON output to specific fields — reduces token usage:
+
+```bash
+sentire events list-issues myorg --fields id,title,status,lastSeen
+sentire events get-issue myorg 12345 --fields id,title,count,userCount
+```
+
+### Pagination
+
+Use `--all` to fetch all pages:
+
+```bash
+sentire events list-issues myorg --all
+```
+
+## Schema Introspection
+
+Use `describe` to discover commands and output fields as JSON:
+
+```bash
+# List all commands with args, flags, and output fields
+sentire describe
+
+# Describe a specific command
+sentire describe events list-issues
+```
+
+## Error Handling
+
+Errors are structured JSON when using `--format json` (default):
+
+```json
+{"error": "message", "code": "error_code"}
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General/unknown error |
+| 2 | Authentication error (missing or invalid token) |
+| 3 | API error (4xx/5xx from Sentry) |
+| 4 | Invalid input (bad slug, ID, URL, or format) |
+
+### Error Codes
+
+- `auth_missing` — SENTRY_API_TOKEN not set
+- `api_error` — Sentry API returned an error
+- `invalid_input` — Bad argument (malformed slug, ID, or URL)
+- `invalid_format` — Unsupported output format
+
+## Tips for AI Agents
+
+1. Use `sentire describe` to discover available commands and their output schemas
+2. Use `--fields` to request only the fields you need — Sentry events can be very large
+3. Use `--format ndjson` for streaming line-by-line processing
+4. Check exit codes for error classification instead of parsing messages
+5. All output goes to stdout, errors go to stderr

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sentire/pkg/models"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var describeCmd = &cobra.Command{
+	Use:   "describe [command-path...]",
+	Short: "Describe available commands and their schemas",
+	Long:  "Output machine-readable JSON describing commands, arguments, flags, and output fields. Use without args to list all commands, or specify a command path (e.g. 'events list-issues') to describe a specific command.",
+	RunE:  runDescribe,
+}
+
+func init() {
+	rootCmd.AddCommand(describeCmd)
+}
+
+type commandDescription struct {
+	Name         string            `json:"name"`
+	Description  string            `json:"description"`
+	Args         []argDescription  `json:"args,omitempty"`
+	Flags        []flagDescription `json:"flags,omitempty"`
+	OutputFields []string          `json:"output_fields,omitempty"`
+}
+
+type argDescription struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+type flagDescription struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Default     string `json:"default,omitempty"`
+	Description string `json:"description"`
+}
+
+type describeOutput struct {
+	Commands []commandDescription `json:"commands"`
+}
+
+var commandModelRegistry = map[string]reflect.Type{
+	"events list-project":    reflect.TypeOf(models.Event{}),
+	"events list-issue":      reflect.TypeOf(models.Event{}),
+	"events list-issues":     reflect.TypeOf(models.Issue{}),
+	"events get-event":       reflect.TypeOf(models.Event{}),
+	"events get-issue":       reflect.TypeOf(models.Issue{}),
+	"events get-issue-event": reflect.TypeOf(models.Event{}),
+	"org list-projects":      reflect.TypeOf(models.Project{}),
+	"org stats":              reflect.TypeOf(models.OrganizationStats{}),
+	"projects list":          reflect.TypeOf(models.Project{}),
+	"projects get":           reflect.TypeOf(models.Project{}),
+	"inspect":                reflect.TypeOf(models.Event{}),
+}
+
+func runDescribe(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		cmdPath := strings.Join(args, " ")
+		desc := describeCommand(rootCmd, cmdPath)
+		if desc == nil {
+			return NewInvalidInputError(fmt.Sprintf("unknown command: %s", cmdPath))
+		}
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(desc)
+	}
+
+	output := describeOutput{
+		Commands: collectCommands(rootCmd, ""),
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(output)
+}
+
+func collectCommands(cmd *cobra.Command, prefix string) []commandDescription {
+	var result []commandDescription
+	for _, child := range cmd.Commands() {
+		if child.Hidden || child.Name() == "help" || child.Name() == "completion" || child.Name() == "describe" {
+			continue
+		}
+		fullName := child.Name()
+		if prefix != "" {
+			fullName = prefix + " " + child.Name()
+		}
+		if child.HasSubCommands() {
+			result = append(result, collectCommands(child, fullName)...)
+		} else {
+			result = append(result, buildDescription(child, fullName))
+		}
+	}
+	return result
+}
+
+func describeCommand(root *cobra.Command, path string) *commandDescription {
+	parts := strings.Fields(path)
+	current := root
+	for _, part := range parts {
+		found := false
+		for _, child := range current.Commands() {
+			if child.Name() == part {
+				current = child
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+	if current == root {
+		return nil
+	}
+	desc := buildDescription(current, path)
+	return &desc
+}
+
+func buildDescription(cmd *cobra.Command, fullName string) commandDescription {
+	desc := commandDescription{
+		Name:        fullName,
+		Description: cmd.Short,
+	}
+
+	desc.Args = parseArgs(cmd.Use)
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		fd := flagDescription{
+			Name:        f.Name,
+			Type:        f.Value.Type(),
+			Description: f.Usage,
+		}
+		if f.DefValue != "" && f.DefValue != "false" && f.DefValue != "0" && f.DefValue != "[]" {
+			fd.Default = f.DefValue
+		}
+		desc.Flags = append(desc.Flags, fd)
+	})
+
+	if modelType, ok := commandModelRegistry[fullName]; ok {
+		desc.OutputFields = extractJSONFields(modelType)
+	}
+
+	return desc
+}
+
+func parseArgs(use string) []argDescription {
+	parts := strings.Fields(use)
+	var args []argDescription
+	for _, p := range parts[1:] {
+		if strings.HasPrefix(p, "<") && strings.HasSuffix(p, ">") {
+			args = append(args, argDescription{
+				Name:     strings.Trim(p, "<>"),
+				Required: true,
+			})
+		} else if strings.HasPrefix(p, "[") && strings.HasSuffix(p, "]") {
+			args = append(args, argDescription{
+				Name:     strings.Trim(p, "[]"),
+				Required: false,
+			})
+		}
+	}
+	return args
+}
+
+func extractJSONFields(t reflect.Type) []string {
+	var fields []string
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name != "" {
+			fields = append(fields, name)
+		}
+	}
+	return fields
+}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sentire/internal/cli/formatter"
+	"sentire/internal/client"
+	"sentire/internal/config"
+)
+
+// Exit codes for different error categories
+const (
+	ExitSuccess       = 0
+	ExitGeneral       = 1
+	ExitAuth          = 2
+	ExitAPI           = 3
+	ExitInvalidInput  = 4
+	ExitInvalidFormat = 4
+)
+
+// Error codes for structured error output
+const (
+	CodeAuthMissing   = "auth_missing"
+	CodeAPIError      = "api_error"
+	CodeInvalidInput  = "invalid_input"
+	CodeInvalidFormat = "invalid_format"
+)
+
+// CLIError represents a structured error with a machine-readable code
+type CLIError struct {
+	Message  string `json:"error"`
+	Code     string `json:"code"`
+	ExitCode int    `json:"-"`
+}
+
+func (e *CLIError) Error() string {
+	return e.Message
+}
+
+// NewAuthError creates an authentication error
+func NewAuthError(message string) *CLIError {
+	return &CLIError{
+		Message:  message,
+		Code:     CodeAuthMissing,
+		ExitCode: ExitAuth,
+	}
+}
+
+// NewAPIError creates an API error
+func NewAPIError(message string) *CLIError {
+	return &CLIError{
+		Message:  message,
+		Code:     CodeAPIError,
+		ExitCode: ExitAPI,
+	}
+}
+
+// NewInvalidInputError creates an invalid input error
+func NewInvalidInputError(message string) *CLIError {
+	return &CLIError{
+		Message:  message,
+		Code:     CodeInvalidInput,
+		ExitCode: ExitInvalidInput,
+	}
+}
+
+// NewInvalidFormatError creates an invalid format error
+func NewInvalidFormatError(message string) *CLIError {
+	return &CLIError{
+		Message:  message,
+		Code:     CodeInvalidFormat,
+		ExitCode: ExitInvalidFormat,
+	}
+}
+
+// wrapError converts known error types into CLIError
+func wrapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(*CLIError); ok {
+		return err
+	}
+	var authErr *config.AuthError
+	if errors.As(err, &authErr) {
+		return NewAuthError(authErr.Message)
+	}
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) {
+		return NewAPIError(apiErr.Message)
+	}
+	var fmtErr *formatter.FormatError
+	if errors.As(err, &fmtErr) {
+		return NewInvalidFormatError(fmtErr.Message)
+	}
+	return err
+}
+
+// writeErrorOutput writes the error to stderr in the appropriate format
+func writeErrorOutput(w io.Writer, err error, format string) {
+	wrapped := wrapError(err)
+	if cliErr, ok := wrapped.(*CLIError); ok && format == "json" {
+		json.NewEncoder(w).Encode(cliErr)
+	} else {
+		fmt.Fprintf(w, "Error: %v\n", err)
+	}
+}
+
+// exitCodeFromError returns the appropriate exit code for an error
+func exitCodeFromError(err error) int {
+	wrapped := wrapError(err)
+	if cliErr, ok := wrapped.(*CLIError); ok {
+		return cliErr.ExitCode
+	}
+	return ExitGeneral
+}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -101,7 +101,7 @@ func wrapError(err error) error {
 // writeErrorOutput writes the error to stderr in the appropriate format
 func writeErrorOutput(w io.Writer, err error, format string) {
 	wrapped := wrapError(err)
-	if cliErr, ok := wrapped.(*CLIError); ok && format == "json" {
+	if cliErr, ok := wrapped.(*CLIError); ok && (format == "json" || format == "ndjson") {
 		json.NewEncoder(w).Encode(cliErr)
 	} else {
 		fmt.Fprintf(w, "Error: %v\n", err)

--- a/internal/cli/events.go
+++ b/internal/cli/events.go
@@ -108,6 +108,13 @@ func init() {
 func runListProjectEvents(cmd *cobra.Command, args []string) error {
 	orgSlug, projectSlug := args[0], args[1]
 
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+	if err := validateProjectSlug(projectSlug); err != nil {
+		return err
+	}
+
 	c, err := client.NewClient()
 	if err != nil {
 		return err
@@ -162,6 +169,13 @@ func runListProjectEvents(cmd *cobra.Command, args []string) error {
 
 func runListIssueEvents(cmd *cobra.Command, args []string) error {
 	orgSlug, issueID := args[0], args[1]
+
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+	if err := validateIssueID(issueID); err != nil {
+		return err
+	}
 
 	c, err := client.NewClient()
 	if err != nil {
@@ -223,6 +237,10 @@ func runListIssueEvents(cmd *cobra.Command, args []string) error {
 
 func runListIssues(cmd *cobra.Command, args []string) error {
 	orgSlug := args[0]
+
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
 
 	c, err := client.NewClient()
 	if err != nil {
@@ -288,6 +306,16 @@ func runListIssues(cmd *cobra.Command, args []string) error {
 func runGetEvent(cmd *cobra.Command, args []string) error {
 	orgSlug, projectSlug, eventID := args[0], args[1], args[2]
 
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+	if err := validateProjectSlug(projectSlug); err != nil {
+		return err
+	}
+	if err := validateEventID(eventID); err != nil {
+		return err
+	}
+
 	c, err := client.NewClient()
 	if err != nil {
 		return err
@@ -305,6 +333,13 @@ func runGetEvent(cmd *cobra.Command, args []string) error {
 func runGetIssue(cmd *cobra.Command, args []string) error {
 	orgSlug, issueID := args[0], args[1]
 
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+	if err := validateIssueID(issueID); err != nil {
+		return err
+	}
+
 	c, err := client.NewClient()
 	if err != nil {
 		return err
@@ -321,6 +356,16 @@ func runGetIssue(cmd *cobra.Command, args []string) error {
 
 func runGetIssueEvent(cmd *cobra.Command, args []string) error {
 	orgSlug, issueID, eventID := args[0], args[1], args[2]
+
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+	if err := validateIssueID(issueID); err != nil {
+		return err
+	}
+	if err := validateEventID(eventID); err != nil {
+		return err
+	}
 
 	c, err := client.NewClient()
 	if err != nil {

--- a/internal/cli/formatter/fields.go
+++ b/internal/cli/formatter/fields.go
@@ -1,0 +1,62 @@
+package formatter
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// filterFields filters data to only include the specified fields.
+// If fields is nil or empty, data is returned unchanged.
+func filterFields(data interface{}, fields []string) interface{} {
+	if len(fields) == 0 {
+		return data
+	}
+
+	v := reflect.ValueOf(data)
+
+	// Handle pointers
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return data
+		}
+		v = v.Elem()
+	}
+
+	// Handle slices: filter each element
+	if v.Kind() == reflect.Slice {
+		result := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			result[i] = filterFields(v.Index(i).Interface(), fields)
+		}
+		return result
+	}
+
+	// For structs and maps, marshal to map then filter keys
+	return filterMap(data, fields)
+}
+
+// filterMap marshals data to a map and keeps only requested fields
+func filterMap(data interface{}, fields []string) interface{} {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return data
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return data
+	}
+
+	keep := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		keep[f] = true
+	}
+
+	filtered := make(map[string]interface{}, len(fields))
+	for k, v := range m {
+		if keep[k] {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}

--- a/internal/cli/formatter/formatter.go
+++ b/internal/cli/formatter/formatter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"sentire/pkg/models"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -36,9 +37,19 @@ func NewFormatter(cmd *cobra.Command, writer io.Writer) (Formatter, error) {
 		writer = os.Stdout
 	}
 
+	var fields []string
+	if fieldsStr, _ := cmd.Flags().GetString("fields"); fieldsStr != "" {
+		for _, f := range strings.Split(fieldsStr, ",") {
+			f = strings.TrimSpace(f)
+			if f != "" {
+				fields = append(fields, f)
+			}
+		}
+	}
+
 	switch format {
 	case "json":
-		return NewJSONFormatter(writer), nil
+		return NewJSONFormatter(writer, fields), nil
 	case "table":
 		return NewTableFormatter(writer), nil
 	case "text":

--- a/internal/cli/formatter/formatter.go
+++ b/internal/cli/formatter/formatter.go
@@ -50,6 +50,8 @@ func NewFormatter(cmd *cobra.Command, writer io.Writer) (Formatter, error) {
 	switch format {
 	case "json":
 		return NewJSONFormatter(writer, fields), nil
+	case "ndjson":
+		return NewNDJSONFormatter(writer, fields), nil
 	case "table":
 		return NewTableFormatter(writer), nil
 	case "text":

--- a/internal/cli/formatter/formatter.go
+++ b/internal/cli/formatter/formatter.go
@@ -1,13 +1,21 @@
 package formatter
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"sentire/pkg/models"
 
 	"github.com/spf13/cobra"
 )
+
+// FormatError represents an unsupported format error
+type FormatError struct {
+	Message string
+}
+
+func (e *FormatError) Error() string {
+	return e.Message
+}
 
 // Formatter defines the interface for different output formats
 type Formatter interface {
@@ -38,7 +46,7 @@ func NewFormatter(cmd *cobra.Command, writer io.Writer) (Formatter, error) {
 	case "markdown":
 		return NewMarkdownFormatter(writer), nil
 	default:
-		return nil, fmt.Errorf("unsupported format: %s", format)
+		return nil, &FormatError{Message: "unsupported format: " + format}
 	}
 }
 

--- a/internal/cli/formatter/json.go
+++ b/internal/cli/formatter/json.go
@@ -9,11 +9,12 @@ import (
 // JSONFormatter outputs data in JSON format (default behavior)
 type JSONFormatter struct {
 	writer io.Writer
+	fields []string
 }
 
 // NewJSONFormatter creates a new JSON formatter
-func NewJSONFormatter(writer io.Writer) *JSONFormatter {
-	return &JSONFormatter{writer: writer}
+func NewJSONFormatter(writer io.Writer, fields []string) *JSONFormatter {
+	return &JSONFormatter{writer: writer, fields: fields}
 }
 
 // FormatEvent formats a single event as JSON
@@ -53,6 +54,7 @@ func (f *JSONFormatter) FormatOrgStats(stats *models.OrganizationStats) error {
 
 // FormatGeneric formats any data as JSON
 func (f *JSONFormatter) FormatGeneric(data interface{}) error {
+	data = filterFields(data, f.fields)
 	encoder := json.NewEncoder(f.writer)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)

--- a/internal/cli/formatter/ndjson.go
+++ b/internal/cli/formatter/ndjson.go
@@ -1,0 +1,83 @@
+package formatter
+
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+	"sentire/pkg/models"
+)
+
+// NDJSONFormatter outputs data as newline-delimited JSON (one object per line)
+type NDJSONFormatter struct {
+	writer io.Writer
+	fields []string
+}
+
+// NewNDJSONFormatter creates a new NDJSON formatter
+func NewNDJSONFormatter(writer io.Writer, fields []string) *NDJSONFormatter {
+	return &NDJSONFormatter{writer: writer, fields: fields}
+}
+
+func (f *NDJSONFormatter) FormatEvent(event *models.Event) error {
+	return f.writeLine(event)
+}
+
+func (f *NDJSONFormatter) FormatEvents(events []models.Event) error {
+	for _, e := range events {
+		if err := f.writeLine(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *NDJSONFormatter) FormatIssue(issue *models.Issue) error {
+	return f.writeLine(issue)
+}
+
+func (f *NDJSONFormatter) FormatIssues(issues []models.Issue) error {
+	for _, i := range issues {
+		if err := f.writeLine(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *NDJSONFormatter) FormatProject(project *models.Project) error {
+	return f.writeLine(project)
+}
+
+func (f *NDJSONFormatter) FormatProjects(projects []models.Project) error {
+	for _, p := range projects {
+		if err := f.writeLine(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *NDJSONFormatter) FormatOrgStats(stats *models.OrganizationStats) error {
+	return f.writeLine(stats)
+}
+
+func (f *NDJSONFormatter) FormatGeneric(data interface{}) error {
+	v := reflect.ValueOf(data)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			if err := f.writeLine(v.Index(i).Interface()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return f.writeLine(data)
+}
+
+func (f *NDJSONFormatter) writeLine(data interface{}) error {
+	data = filterFields(data, f.fields)
+	return json.NewEncoder(f.writer).Encode(data)
+}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -69,7 +69,7 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	// Parse the URL to extract organization and issue ID
 	parts, err := parseSentryURL(sentryURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse Sentry URL: %w", err)
+		return NewInvalidInputError(fmt.Sprintf("failed to parse Sentry URL: %v", err))
 	}
 
 	// Create API client

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -66,6 +66,10 @@ func parseSentryURL(rawURL string) (*SentryURLParts, error) {
 func runInspect(cmd *cobra.Command, args []string) error {
 	sentryURL := args[0]
 
+	if err := validateInspectURL(sentryURL); err != nil {
+		return err
+	}
+
 	// Parse the URL to extract organization and issue ID
 	parts, err := parseSentryURL(sentryURL)
 	if err != nil {

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -55,6 +55,10 @@ func init() {
 func runListOrgProjects(cmd *cobra.Command, args []string) error {
 	orgSlug := args[0]
 
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+
 	c, err := client.NewClient()
 	if err != nil {
 		return err
@@ -93,6 +97,10 @@ func runListOrgProjects(cmd *cobra.Command, args []string) error {
 
 func runGetOrgStats(cmd *cobra.Command, args []string) error {
 	orgSlug := args[0]
+
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
 
 	c, err := client.NewClient()
 	if err != nil {

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -80,6 +80,13 @@ func runListProjects(cmd *cobra.Command, args []string) error {
 func runGetProject(cmd *cobra.Command, args []string) error {
 	orgSlug, projectSlug := args[0], args[1]
 
+	if err := validateOrgSlug(orgSlug); err != nil {
+		return err
+	}
+	if err := validateProjectSlug(projectSlug); err != nil {
+		return err
+	}
+
 	c, err := client.NewClient()
 	if err != nil {
 		return err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,4 +33,5 @@ func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringP("format", "f", "json", "Output format: json, table, text, markdown")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
+	rootCmd.PersistentFlags().String("fields", "", "Comma-separated list of fields to include in JSON output")
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ func Execute() {
 
 func init() {
 	// Global flags
-	rootCmd.PersistentFlags().StringP("format", "f", "json", "Output format: json, table, text, markdown")
+	rootCmd.PersistentFlags().StringP("format", "f", "json", "Output format: json, ndjson, table, text, markdown")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
 	rootCmd.PersistentFlags().String("fields", "", "Comma-separated list of fields to include in JSON output")
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -17,14 +16,16 @@ It allows you to query events, issues, projects, and organizations directly from
 
 Before using sentire, make sure to set your Sentry API token:
   export SENTRY_API_TOKEN=your_token_here`,
-	SilenceUsage: true,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 // Execute runs the root command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		format, _ := rootCmd.PersistentFlags().GetString("format")
+		writeErrorOutput(os.Stderr, err, format)
+		os.Exit(exitCodeFromError(err))
 	}
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	slugRegex    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	issueIDRegex = regexp.MustCompile(`^\d+$`)
+	eventIDRegex = regexp.MustCompile(`^[a-f0-9]{32}$`)
+)
+
+const maxSlugLength = 50
+
+var specialEventIDs = map[string]bool{
+	"latest":      true,
+	"oldest":      true,
+	"recommended": true,
+}
+
+func validateOrgSlug(slug string) error {
+	if len(slug) > maxSlugLength {
+		return NewInvalidInputError(fmt.Sprintf("organization slug too long (max %d chars): %s", maxSlugLength, slug))
+	}
+	if !slugRegex.MatchString(slug) {
+		return NewInvalidInputError(fmt.Sprintf("invalid organization slug: %q (must match [a-z0-9][a-z0-9-]*)", slug))
+	}
+	return nil
+}
+
+func validateProjectSlug(slug string) error {
+	if len(slug) > maxSlugLength {
+		return NewInvalidInputError(fmt.Sprintf("project slug too long (max %d chars): %s", maxSlugLength, slug))
+	}
+	if !slugRegex.MatchString(slug) {
+		return NewInvalidInputError(fmt.Sprintf("invalid project slug: %q (must match [a-z0-9][a-z0-9-]*)", slug))
+	}
+	return nil
+}
+
+func validateIssueID(id string) error {
+	if !issueIDRegex.MatchString(id) {
+		return NewInvalidInputError(fmt.Sprintf("invalid issue ID: %q (must be numeric)", id))
+	}
+	return nil
+}
+
+func validateEventID(id string) error {
+	if specialEventIDs[id] {
+		return nil
+	}
+	if !eventIDRegex.MatchString(id) {
+		return NewInvalidInputError(fmt.Sprintf("invalid event ID: %q (must be 32 hex chars or latest/oldest/recommended)", id))
+	}
+	return nil
+}
+
+func validateInspectURL(rawURL string) error {
+	if !strings.Contains(rawURL, "sentry.io") {
+		return NewInvalidInputError(fmt.Sprintf("invalid Sentry URL: %q (must contain sentry.io)", rawURL))
+	}
+	return nil
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -48,6 +48,16 @@ type Response struct {
 	Pagination *PaginationInfo
 }
 
+// APIError represents an error returned by the Sentry API
+type APIError struct {
+	Message    string
+	StatusCode int
+}
+
+func (e *APIError) Error() string {
+	return e.Message
+}
+
 // NewClient creates a new Sentry API client
 func NewClient() (*Client, error) {
 	cfg, err := config.LoadConfig()
@@ -92,7 +102,10 @@ func (c *Client) Do(req *http.Request) (*Response, error) {
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
-		return response, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		return response, &APIError{
+			Message:    fmt.Sprintf("API request failed with status %d: %s", resp.StatusCode, string(body)),
+			StatusCode: resp.StatusCode,
+		}
 	}
 
 	return response, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,15 @@ import (
 	"path/filepath"
 )
 
+// AuthError represents an authentication configuration error
+type AuthError struct {
+	Message string
+}
+
+func (e *AuthError) Error() string {
+	return e.Message
+}
+
 // Config holds the application configuration
 type Config struct {
 	SentryAPIToken string `json:"sentry_api_token"`
@@ -31,12 +40,12 @@ func LoadConfig() (*Config, error) {
 
 	if err := loadFromFile(configPath, config); err != nil {
 		// If config file doesn't exist or has issues, return error about missing token
-		return nil, fmt.Errorf("SENTRY_API_TOKEN environment variable is required (or configure ~/.config/sentire/config.json)")
+		return nil, &AuthError{Message: "SENTRY_API_TOKEN environment variable is required (or configure ~/.config/sentire/config.json)"}
 	}
 
 	// Validate that we have a token
 	if config.SentryAPIToken == "" {
-		return nil, fmt.Errorf("SENTRY_API_TOKEN is required in config file")
+		return nil, &AuthError{Message: "SENTRY_API_TOKEN is required in config file"}
 	}
 
 	return config, nil

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -12,9 +12,12 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	// Test with missing token
+	// Test with missing token (also override HOME to avoid loading config file)
 	os.Unsetenv("SENTRY_API_TOKEN")
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
 	_, err := client.NewClient()
+	os.Setenv("HOME", originalHome)
 	if err == nil {
 		t.Error("Expected error when SENTRY_API_TOKEN is not set")
 	}

--- a/tests/describe_test.go
+++ b/tests/describe_test.go
@@ -1,0 +1,118 @@
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestDescribeAllCommands(t *testing.T) {
+	binary := buildSentire(t)
+	stdout, _, exitCode := runSentire(t, binary, "describe")
+
+	if exitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d", exitCode)
+	}
+
+	var result struct {
+		Commands []struct {
+			Name         string   `json:"name"`
+			Description  string   `json:"description"`
+			OutputFields []string `json:"output_fields"`
+		} `json:"commands"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("Invalid JSON output: %v\nOutput: %s", err, stdout)
+	}
+
+	if len(result.Commands) == 0 {
+		t.Fatal("Expected at least one command in describe output")
+	}
+
+	found := make(map[string]bool)
+	for _, cmd := range result.Commands {
+		found[cmd.Name] = true
+	}
+
+	expectedCommands := []string{
+		"events list-issues",
+		"events get-issue",
+		"events get-event",
+		"inspect",
+		"projects list",
+		"projects get",
+		"org list-projects",
+		"org stats",
+	}
+
+	for _, name := range expectedCommands {
+		if !found[name] {
+			t.Errorf("Expected command %q in describe output", name)
+		}
+	}
+}
+
+func TestDescribeSpecificCommand(t *testing.T) {
+	binary := buildSentire(t)
+	stdout, _, exitCode := runSentire(t, binary, "describe", "events", "list-issues")
+
+	if exitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d", exitCode)
+	}
+
+	var result struct {
+		Name         string   `json:"name"`
+		Description  string   `json:"description"`
+		OutputFields []string `json:"output_fields"`
+		Args         []struct {
+			Name     string `json:"name"`
+			Required bool   `json:"required"`
+		} `json:"args"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("Invalid JSON output: %v\nOutput: %s", err, stdout)
+	}
+
+	if result.Name != "events list-issues" {
+		t.Errorf("Expected name 'events list-issues', got %q", result.Name)
+	}
+
+	if len(result.Args) == 0 {
+		t.Error("Expected at least one arg")
+	}
+
+	if len(result.OutputFields) == 0 {
+		t.Error("Expected output_fields to be populated")
+	}
+
+	fieldSet := make(map[string]bool)
+	for _, f := range result.OutputFields {
+		fieldSet[f] = true
+	}
+	for _, expected := range []string{"id", "title", "status", "lastSeen"} {
+		if !fieldSet[expected] {
+			t.Errorf("Expected output field %q", expected)
+		}
+	}
+}
+
+func TestDescribeUnknownCommand(t *testing.T) {
+	binary := buildSentire(t)
+
+	cmd := exec.Command(binary, "describe", "nonexistent")
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "SENTRY_API_TOKEN=test"}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	exitCode := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	}
+
+	if exitCode != 4 {
+		t.Errorf("Expected exit code 4 for unknown command, got %d", exitCode)
+	}
+}

--- a/tests/errors_test.go
+++ b/tests/errors_test.go
@@ -1,0 +1,150 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"sentire/internal/cli/formatter"
+	"sentire/internal/client"
+	"sentire/internal/config"
+	"strings"
+	"testing"
+)
+
+func TestCLIErrorJSON(t *testing.T) {
+	type CLIError struct {
+		Message  string `json:"error"`
+		Code     string `json:"code"`
+		ExitCode int    `json:"-"`
+	}
+
+	err := CLIError{
+		Message:  "SENTRY_API_TOKEN not set",
+		Code:     "auth_missing",
+		ExitCode: 2,
+	}
+
+	b, marshalErr := json.Marshal(err)
+	if marshalErr != nil {
+		t.Fatalf("Failed to marshal CLIError: %v", marshalErr)
+	}
+
+	var result map[string]interface{}
+	json.Unmarshal(b, &result)
+
+	if result["error"] != "SENTRY_API_TOKEN not set" {
+		t.Errorf("Expected error field, got %v", result["error"])
+	}
+	if result["code"] != "auth_missing" {
+		t.Errorf("Expected code field, got %v", result["code"])
+	}
+	if _, ok := result["ExitCode"]; ok {
+		t.Error("ExitCode should not be in JSON output")
+	}
+}
+
+func TestAuthErrorType(t *testing.T) {
+	err := &config.AuthError{Message: "token missing"}
+	if err.Error() != "token missing" {
+		t.Errorf("Expected 'token missing', got %q", err.Error())
+	}
+}
+
+func TestAPIErrorType(t *testing.T) {
+	err := &client.APIError{Message: "not found", StatusCode: 404}
+	if err.Error() != "not found" {
+		t.Errorf("Expected 'not found', got %q", err.Error())
+	}
+	if err.StatusCode != 404 {
+		t.Errorf("Expected status 404, got %d", err.StatusCode)
+	}
+}
+
+func TestFormatErrorType(t *testing.T) {
+	err := &formatter.FormatError{Message: "unsupported format: xml"}
+	if err.Error() != "unsupported format: xml" {
+		t.Errorf("Expected error message, got %q", err.Error())
+	}
+}
+
+func TestUnsupportedFormatReturnsFormatError(t *testing.T) {
+	cmd := createTestCommand("xml")
+	cmd.Flags().Set("format", "xml")
+
+	var buf bytes.Buffer
+	_, err := formatter.NewFormatter(cmd, &buf)
+	if err == nil {
+		t.Fatal("Expected error for unsupported format")
+	}
+
+	_, ok := err.(*formatter.FormatError)
+	if !ok {
+		t.Errorf("Expected *formatter.FormatError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "xml") {
+		t.Errorf("Expected error to mention 'xml', got %q", err.Error())
+	}
+}
+
+func buildSentire(t *testing.T) string {
+	t.Helper()
+	binary := t.TempDir() + "/sentire"
+	cmd := exec.Command("go", "build", "-o", binary, "./cmd/sentire")
+	cmd.Dir = ".."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to build sentire: %v\n%s", err, out)
+	}
+	return binary
+}
+
+func runSentire(t *testing.T, binary string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(), "SENTRY_API_TOKEN=test-token")
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("Failed to run sentire: %v", err)
+	}
+	return stdout.String(), stderr.String(), exitCode
+}
+
+func TestExitCodeAuthError(t *testing.T) {
+	binary := buildSentire(t)
+
+	cmd := exec.Command(binary, "events", "list-issues", "my-org")
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=/tmp/nonexistent"}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	exitCode := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	}
+
+	if exitCode != 2 {
+		t.Errorf("Expected exit code 2 for auth error, got %d\nstderr: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "auth_missing") {
+		t.Errorf("Expected stderr to contain 'auth_missing', got %q", stderr.String())
+	}
+}
+
+func TestExitCodeAPIError(t *testing.T) {
+	binary := buildSentire(t)
+
+	// Use a valid slug so validation passes, then the API call will fail
+	_, stderr, exitCode := runSentire(t, binary, "events", "list-issues", "my-org")
+
+	if exitCode != 3 {
+		t.Errorf("Expected exit code 3 for API error, got %d\nstderr: %s", exitCode, stderr)
+	}
+}

--- a/tests/fields_test.go
+++ b/tests/fields_test.go
@@ -1,0 +1,127 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"sentire/internal/cli/formatter"
+	"sentire/pkg/models"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func createTestCommandWithFields(format, fields string) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().StringP("format", "f", format, "Test format flag")
+	cmd.Flags().String("fields", fields, "Test fields flag")
+	return cmd
+}
+
+func TestFieldsFilteringSingleObject(t *testing.T) {
+	issue := &models.Issue{
+		ID:      "123",
+		ShortID: "PROJ-1",
+		Title:   "Test Issue",
+		Status:  "unresolved",
+		Level:   "error",
+	}
+
+	var buf bytes.Buffer
+	cmd := createTestCommandWithFields("json", "id,title,status")
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	if err := f.FormatIssue(issue); err != nil {
+		t.Fatalf("Failed to format issue: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 fields, got %d: %v", len(result), result)
+	}
+	if result["id"] != "123" {
+		t.Errorf("Expected id=123, got %v", result["id"])
+	}
+	if result["title"] != "Test Issue" {
+		t.Errorf("Expected title=Test Issue, got %v", result["title"])
+	}
+	if result["status"] != "unresolved" {
+		t.Errorf("Expected status=unresolved, got %v", result["status"])
+	}
+}
+
+func TestFieldsFilteringSlice(t *testing.T) {
+	events := []models.Event{
+		{ID: "e1", EventID: "evt1", Title: "First", DateCreated: time.Now()},
+		{ID: "e2", EventID: "evt2", Title: "Second", DateCreated: time.Now()},
+	}
+
+	var buf bytes.Buffer
+	cmd := createTestCommandWithFields("json", "id,title")
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	if err := f.FormatEvents(events); err != nil {
+		t.Fatalf("Failed to format events: %v", err)
+	}
+
+	var result []map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 items, got %d", len(result))
+	}
+
+	for i, item := range result {
+		if len(item) != 2 {
+			t.Errorf("Item %d: expected 2 fields, got %d: %v", i, len(item), item)
+		}
+		if _, ok := item["id"]; !ok {
+			t.Errorf("Item %d: missing 'id' field", i)
+		}
+		if _, ok := item["title"]; !ok {
+			t.Errorf("Item %d: missing 'title' field", i)
+		}
+	}
+}
+
+func TestNoFieldsFilteringReturnsAll(t *testing.T) {
+	issue := &models.Issue{
+		ID:      "123",
+		ShortID: "PROJ-1",
+		Title:   "Test Issue",
+		Status:  "unresolved",
+		Level:   "error",
+	}
+
+	var buf bytes.Buffer
+	cmd := createTestCommandWithFields("json", "")
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	if err := f.FormatIssue(issue); err != nil {
+		t.Fatalf("Failed to format issue: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse output: %v", err)
+	}
+
+	if len(result) < 5 {
+		t.Errorf("Expected many fields without filter, got %d", len(result))
+	}
+}

--- a/tests/ndjson_test.go
+++ b/tests/ndjson_test.go
@@ -1,0 +1,113 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"sentire/internal/cli/formatter"
+	"sentire/pkg/models"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNDJSONSingleObject(t *testing.T) {
+	issue := &models.Issue{
+		ID:    "123",
+		Title: "Test Issue",
+	}
+
+	var buf bytes.Buffer
+	cmd := createTestCommandWithFields("ndjson", "")
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	if err := f.FormatIssue(issue); err != nil {
+		t.Fatalf("Failed to format issue: %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	lines := strings.Split(output, "\n")
+	if len(lines) != 1 {
+		t.Errorf("Expected 1 line, got %d", len(lines))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[0]), &result); err != nil {
+		t.Fatalf("Line is not valid JSON: %v", err)
+	}
+	if result["id"] != "123" {
+		t.Errorf("Expected id=123, got %v", result["id"])
+	}
+}
+
+func TestNDJSONMultipleObjects(t *testing.T) {
+	events := []models.Event{
+		{ID: "e1", Title: "First", DateCreated: time.Now()},
+		{ID: "e2", Title: "Second", DateCreated: time.Now()},
+		{ID: "e3", Title: "Third", DateCreated: time.Now()},
+	}
+
+	var buf bytes.Buffer
+	cmd := createTestCommandWithFields("ndjson", "")
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	if err := f.FormatEvents(events); err != nil {
+		t.Fatalf("Failed to format events: %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	lines := strings.Split(output, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("Expected 3 lines, got %d", len(lines))
+	}
+
+	for i, line := range lines {
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &result); err != nil {
+			t.Errorf("Line %d is not valid JSON: %v", i, err)
+		}
+	}
+
+	if strings.Contains(buf.String(), "[") || strings.Contains(buf.String(), "]") {
+		t.Error("NDJSON output should not contain array brackets")
+	}
+}
+
+func TestNDJSONWithFieldsFilter(t *testing.T) {
+	events := []models.Event{
+		{ID: "e1", EventID: "evt1", Title: "First", DateCreated: time.Now()},
+		{ID: "e2", EventID: "evt2", Title: "Second", DateCreated: time.Now()},
+	}
+
+	var buf bytes.Buffer
+	cmd := createTestCommandWithFields("ndjson", "id,title")
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	if err := f.FormatEvents(events); err != nil {
+		t.Fatalf("Failed to format events: %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	lines := strings.Split(output, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 lines, got %d", len(lines))
+	}
+
+	for i, line := range lines {
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &result); err != nil {
+			t.Fatalf("Line %d: invalid JSON: %v", i, err)
+		}
+		if len(result) != 2 {
+			t.Errorf("Line %d: expected 2 fields, got %d: %v", i, len(result), result)
+		}
+	}
+}

--- a/tests/validate_test.go
+++ b/tests/validate_test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateOrgSlug(t *testing.T) {
+	binary := buildSentire(t)
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantExitCode int
+		wantStderr   string
+	}{
+		{
+			name:         "valid org slug",
+			args:         []string{"events", "list-issues", "my-org"},
+			wantExitCode: 3, // API error since we're hitting a fake token
+		},
+		{
+			name:         "invalid org slug with uppercase",
+			args:         []string{"events", "list-issues", "MyOrg"},
+			wantExitCode: 4,
+			wantStderr:   "invalid_input",
+		},
+		{
+			name:         "invalid org slug with special chars",
+			args:         []string{"events", "list-issues", "my@org!"},
+			wantExitCode: 4,
+			wantStderr:   "invalid_input",
+		},
+		{
+			name:         "invalid issue ID non-numeric",
+			args:         []string{"events", "get-issue", "my-org", "abc"},
+			wantExitCode: 4,
+			wantStderr:   "invalid_input",
+		},
+		{
+			name:         "valid issue ID",
+			args:         []string{"events", "get-issue", "my-org", "123456"},
+			wantExitCode: 3, // API error
+		},
+		{
+			name:         "invalid event ID",
+			args:         []string{"events", "get-event", "my-org", "my-project", "not-hex"},
+			wantExitCode: 4,
+			wantStderr:   "invalid_input",
+		},
+		{
+			name:         "valid special event ID",
+			args:         []string{"events", "get-issue-event", "my-org", "12345", "recommended"},
+			wantExitCode: 3, // API error
+		},
+		{
+			name:         "inspect with non-sentry URL",
+			args:         []string{"inspect", "https://example.com/issues/123"},
+			wantExitCode: 4,
+			wantStderr:   "invalid_input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, stderr, exitCode := runSentire(t, binary, tt.args...)
+			if exitCode != tt.wantExitCode {
+				t.Errorf("exit code = %d, want %d\nstderr: %s", exitCode, tt.wantExitCode, stderr)
+			}
+			if tt.wantStderr != "" && !strings.Contains(stderr, tt.wantStderr) {
+				t.Errorf("stderr = %q, want it to contain %q", stderr, tt.wantStderr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Structured errors**: Typed `CLIError` with machine-readable codes (`auth_missing`, `api_error`, `invalid_input`, `invalid_format`) and distinct exit codes (0=success, 1=general, 2=auth, 3=API, 4=invalid input). Errors output as JSON to stderr when format is json/ndjson.
- **Input validation**: Validates org/project slugs, issue IDs, event IDs, and inspect URLs before making API calls. Catches malformed input from hallucinating agents.
- **`--fields` flag**: Filters JSON output to only requested fields (e.g. `--fields id,title,status`). Reduces token usage for large Sentry payloads.
- **`--format ndjson`**: Newline-delimited JSON output — one object per line, no array brackets. Useful for streaming and piping through jq.
- **`describe` command**: Machine-readable JSON introspection of all commands, args, flags, and output fields. Supports `sentire describe` (all) and `sentire describe events list-issues` (specific).
- **`context` command + CONTEXT.md**: Agent-specific usage guide with command reference, error codes, and tips.
- Also fixes a pre-existing `TestNewClient` test failure when a config file exists at `~/.config/sentire/config.json`.

## Test plan

- [x] `make test` passes (51 tests, 0 failures)
- [x] `make build` succeeds
- [x] New tests cover: structured errors, input validation (valid/invalid slugs, IDs, URLs, exit codes), field filtering (single/slice/no-filter), NDJSON (single/multiple/with-fields), describe (all/specific/unknown)