### PR TITLE
ci: add Go 1.24 and 1.25 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.26.1']
-    
+        go-version: ['1.24', '1.25', '1.26.1']
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -57,8 +57,8 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.26.1']
-    
+        go-version: ['1.24', '1.25', '1.26.1']
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,14 @@
 module sentire
 
-go 1.26.1
+go 1.24
+
+toolchain go1.26.1
+
+require (
+	github.com/olekukonko/tablewriter v1.0.9
+	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
+)
 
 require (
 	github.com/fatih/color v1.15.0 // indirect
@@ -10,9 +18,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.0.9 // indirect
-	github.com/olekukonko/tablewriter v1.0.9 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )


### PR DESCRIPTION
## Summary
- Expand CI test and build matrices to include Go 1.24 and 1.25 alongside 1.26.1
- Ensures backward compatibility with the two previous Go minor versions

## Test plan
- [ ] CI passes for all three Go versions in the matrix