### PR TITLE
Redact Sentry API token from error and verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Set your Sentry API token as an environment variable:
 export SENTRY_API_TOKEN=your_sentry_api_token_here
 ```
 
+To avoid recording the token in your shell history, prefix the command with a
+space (when `HISTCONTROL` includes `ignorespace`) or load it from a credential
+manager.
+
 ### Configuration File
 
 Alternatively, you can create a configuration file at `~/.config/sentire/config.json`:
@@ -69,6 +73,12 @@ Alternatively, you can create a configuration file at `~/.config/sentire/config.
 }
 ```
 
+Restrict access to that file so other users on the system cannot read it:
+
+```bash
+chmod 600 ~/.config/sentire/config.json
+```
+
 ### Configuration Precedence
 
 If both are provided, the environment variable takes precedence over the configuration file. This allows you to:
@@ -77,6 +87,15 @@ If both are provided, the environment variable takes precedence over the configu
 - Override it temporarily with an environment variable when needed
 
 You can obtain an API token from your Sentry organization settings under "Auth Tokens".
+
+### Token Safety in Output
+
+Sentire never prints the configured token in standard, verbose, or error
+output: the API response body included in error messages and the final CLI
+error writer both run through a redaction helper that replaces the token with
+`[REDACTED]`. Do not share raw command output that contains your token (for
+example, if you pasted it directly into the URL or another argument), since
+only the configured token can be redacted automatically.
 
 ## Usage
 

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -7,7 +7,9 @@ import (
 	"github.com/andreagrandi/sentire/internal/cli/formatter"
 	"github.com/andreagrandi/sentire/internal/client"
 	"github.com/andreagrandi/sentire/internal/config"
+	"github.com/andreagrandi/sentire/internal/redact"
 	"io"
+	"os"
 )
 
 // Exit codes for different error categories
@@ -98,14 +100,33 @@ func wrapError(err error) error {
 	return err
 }
 
-// writeErrorOutput writes the error to stderr in the appropriate format
+// writeErrorOutput writes the error to stderr in the appropriate format.
+// All output is run through token redaction as a defense-in-depth measure so
+// that even an error message constructed outside the client never leaks the
+// Sentry API token.
 func writeErrorOutput(w io.Writer, err error, format string) {
 	wrapped := wrapError(err)
+	secret := loadSecretForRedaction()
 	if cliErr, ok := wrapped.(*CLIError); ok && (format == "json" || format == "ndjson") {
+		cliErr.Message = redact.Secret(cliErr.Message, secret)
 		json.NewEncoder(w).Encode(cliErr)
 	} else {
-		fmt.Fprintf(w, "Error: %v\n", err)
+		fmt.Fprintf(w, "Error: %s\n", redact.Secret(err.Error(), secret))
 	}
+}
+
+// loadSecretForRedaction returns the configured Sentry API token, falling back
+// to the config file when the env var is unset. Returns "" if neither is set,
+// in which case redaction is a no-op.
+func loadSecretForRedaction() string {
+	if t := os.Getenv("SENTRY_API_TOKEN"); t != "" {
+		return t
+	}
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return ""
+	}
+	return cfg.SentryAPIToken
 }
 
 // exitCodeFromError returns the appropriate exit code for an error

--- a/internal/cli/errors_redact_test.go
+++ b/internal/cli/errors_redact_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andreagrandi/sentire/internal/redact"
+)
+
+// TestWriteErrorOutputRedactsToken verifies the CLI's final error writer
+// strips the SENTRY_API_TOKEN value regardless of which upstream layer
+// produced the error.
+func TestWriteErrorOutputRedactsToken(t *testing.T) {
+	const token = "cli-secret-token"
+
+	os.Setenv("SENTRY_API_TOKEN", token)
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	cases := []struct {
+		name   string
+		format string
+		err    error
+	}{
+		{
+			name:   "json CLIError",
+			format: "json",
+			err:    NewAPIError("API request failed: token leaked " + token),
+		},
+		{
+			name:   "ndjson CLIError",
+			format: "ndjson",
+			err:    NewAPIError("API request failed: token leaked " + token),
+		},
+		{
+			name:   "text plain error",
+			format: "text",
+			err:    errors.New("unexpected failure containing " + token),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writeErrorOutput(&buf, tc.err, tc.format)
+
+			out := buf.String()
+			if strings.Contains(out, token) {
+				t.Errorf("Token leaked in %s output: %s", tc.format, out)
+			}
+			if !strings.Contains(out, redact.Placeholder) {
+				t.Errorf("Expected placeholder %q in %s output, got: %s", redact.Placeholder, tc.format, out)
+			}
+		})
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/andreagrandi/sentire/internal/config"
+	"github.com/andreagrandi/sentire/internal/redact"
 	"io"
 	"net/http"
 	"net/url"
@@ -84,7 +85,9 @@ func (c *Client) Do(req *http.Request) (*Response, error) {
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("http request failed: %w", err)
+		// Transport errors come from net/http and may include the request URL;
+		// strip the token defensively in case it ever surfaces in a wrapped error.
+		return nil, fmt.Errorf("http request failed: %s", redact.Secret(err.Error(), c.Token))
 	}
 
 	// Parse rate limit headers
@@ -103,7 +106,7 @@ func (c *Client) Do(req *http.Request) (*Response, error) {
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
 		return response, &APIError{
-			Message:    fmt.Sprintf("API request failed with status %d: %s", resp.StatusCode, string(body)),
+			Message:    fmt.Sprintf("API request failed with status %d: %s", resp.StatusCode, redact.Secret(string(body), c.Token)),
 			StatusCode: resp.StatusCode,
 		}
 	}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,16 @@
+package redact
+
+import "strings"
+
+// Placeholder is the string used to replace a redacted secret.
+const Placeholder = "[REDACTED]"
+
+// Secret returns s with every occurrence of secret replaced by Placeholder.
+// An empty secret is treated as a no-op so callers can apply this even when
+// the token has not been loaded yet.
+func Secret(s, secret string) string {
+	if secret == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, secret, Placeholder)
+}

--- a/tests/redact_test.go
+++ b/tests/redact_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andreagrandi/sentire/internal/client"
+	"github.com/andreagrandi/sentire/internal/redact"
+)
+
+func TestRedactSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		secret string
+		want   string
+	}{
+		{
+			name:   "replaces bare token",
+			input:  "auth=abc123",
+			secret: "abc123",
+			want:   "auth=" + redact.Placeholder,
+		},
+		{
+			name:   "replaces multiple occurrences",
+			input:  "abc123 and abc123 again",
+			secret: "abc123",
+			want:   redact.Placeholder + " and " + redact.Placeholder + " again",
+		},
+		{
+			name:   "redacts Bearer-prefixed token via substring match",
+			input:  "Authorization: Bearer abc123",
+			secret: "abc123",
+			want:   "Authorization: Bearer " + redact.Placeholder,
+		},
+		{
+			name:   "empty secret is a no-op",
+			input:  "anything",
+			secret: "",
+			want:   "anything",
+		},
+		{
+			name:   "no occurrence leaves string untouched",
+			input:  "nothing to see",
+			secret: "abc123",
+			want:   "nothing to see",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redact.Secret(tc.input, tc.secret)
+			if got != tc.want {
+				t.Errorf("Secret(%q, %q) = %q, want %q", tc.input, tc.secret, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClientAPIErrorRedactsTokenInBody guards against the case where the
+// upstream API echoes the Sentry token in an error response body.
+func TestClientAPIErrorRedactsTokenInBody(t *testing.T) {
+	const token = "super-secret-token-value"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "invalid token: ` + token + `"}`))
+	}))
+	defer server.Close()
+
+	os.Setenv("SENTRY_API_TOKEN", token)
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	c, err := client.NewClient()
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	c.BaseURL = server.URL
+
+	_, err = c.Get("/test", nil)
+	if err == nil {
+		t.Fatal("Expected error for 401 response")
+	}
+
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("Expected token to be redacted in error message, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), redact.Placeholder) {
+		t.Errorf("Expected error message to contain placeholder %q, got: %s", redact.Placeholder, err.Error())
+	}
+}
+
+// TestClientTransportErrorRedactsToken simulates a transport failure where the
+// token has somehow ended up in the URL, and verifies it is stripped from the
+// wrapped error message that net/http surfaces.
+func TestClientTransportErrorRedactsToken(t *testing.T) {
+	const token = "transport-error-token"
+
+	os.Setenv("SENTRY_API_TOKEN", token)
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	c, err := client.NewClient()
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	c.BaseURL = "http://invalid.localhost.invalid/" + token
+
+	_, err = c.Get("/test", nil)
+	if err == nil {
+		t.Fatal("Expected transport error for unreachable host")
+	}
+
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("Expected token to be redacted in transport error, got: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/redact` helper that replaces a configured secret with `[REDACTED]` (no-op when the secret is empty).
- Apply redaction at the client boundary (response bodies embedded in `APIError`, wrapped transport errors) and at the CLI's final error writer for `json`, `ndjson`, and `text` formats.
- Document safer token handling in the README (shell history, `chmod 600` on the config file) and call out the redaction behaviour so users know not to share raw output.

Closes #22.

## Test plan
- [x] `go test ./...` (all existing tests + new regression tests pass)
- [x] `tests/redact_test.go` — table tests for `redact.Secret` plus mock-server tests for `APIError` body redaction and transport-error redaction
- [x] `internal/cli/errors_redact_test.go` — `writeErrorOutput` redaction across `json`, `ndjson`, and `text` formats
- [x] `make fmt` clean