### PR TITLE
feat: expand agent workflows in context and describe docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Sentire will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Agent workflow recipes in `context` output and `CONTEXT.md` (triage, URL inspection, release reporting)
+- README section pointing agents at `sentire context` and `sentire describe`
+- Test coverage locking the `describe` output schema and the agent context guide
+
+### Fixed
+- Redact `SENTRY_API_TOKEN` from error and verbose output
+
+### Technical
+- Use full GitHub module path (`github.com/andreagrandi/sentire`) for public `go install`
+- Bump `github.com/spf13/cobra` from 1.8.1 to 1.10.2
+- Lower `go.mod` minimum to Go 1.24 and add Go 1.24/1.25 to the CI build matrix
+
 ## [0.3.0] - 2026-03-07
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,6 +69,10 @@ Default output is JSON. Available formats: `json`, `ndjson`, `table`, `text`, `m
 sentire events list-issues myorg --format ndjson
 ```
 
+For agent pipelines, prefer `json` (default) or `ndjson`. The `table`, `text`,
+and `markdown` formats are intended for humans and may change formatting
+between releases — do not parse them.
+
 ### Field Filtering
 
 Use `--fields` to limit JSON output to specific fields — reduces token usage:
@@ -78,6 +82,11 @@ sentire events list-issues myorg --fields id,title,status,lastSeen
 sentire events get-issue myorg 12345 --fields id,title,count,userCount
 ```
 
+Field names match the top-level JSON keys returned by Sentry. Run
+`sentire describe <command>` to see the supported `output_fields` for each
+command before composing a `--fields` list — unknown names are silently
+dropped, so check first.
+
 ### Pagination
 
 Use `--all` to fetch all pages:
@@ -85,6 +94,25 @@ Use `--all` to fetch all pages:
 ```bash
 sentire events list-issues myorg --all
 ```
+
+`--all` follows cursor-based pagination until exhausted, which can return
+large amounts of data. For exploration, omit `--all` and use `--limit` plus
+`--fields` first; only enable `--all` when you genuinely need every page.
+
+### Query Filters
+
+The `--query` flag on `events list-issues` and `events list-issue` accepts
+Sentry's search syntax. Common, safe building blocks:
+
+- `is:unresolved`, `is:resolved`, `is:ignored`
+- `issue.priority:[high,medium]`
+- `level:error`, `level:warning`
+- `environment:production`
+- `firstSeen:-24h`, `lastSeen:-7d`
+- `assigned:me`, `assigned:#team-slug`
+
+Combine terms with spaces (implicit AND). Always quote the full value when
+it contains spaces or brackets so the shell does not split it.
 
 ## Schema Introspection
 
@@ -97,6 +125,82 @@ sentire describe
 # Describe a specific command
 sentire describe events list-issues
 ```
+
+The `describe` output schema is stable — each command entry exposes `name`,
+`description`, `args`, `flags`, and `output_fields`. Agents can rely on these
+keys when generating subsequent invocations.
+
+## Agent Workflows
+
+The following recipes show end-to-end flows an agent can run without any
+human input. Each step uses only stable JSON output and exit codes for
+control flow.
+
+### Workflow 1: Triage unresolved issues for an organization
+
+Goal: produce a short, ranked list of issues that deserve attention this
+week.
+
+```bash
+# 1. Pull the top unresolved high/medium priority issues from the last 7 days,
+#    keep only the fields needed for ranking.
+sentire events list-issues myorg \
+  --query "is:unresolved issue.priority:[high,medium]" \
+  --period 7d \
+  --fields id,shortId,title,level,count,userCount,lastSeen,permalink \
+  --format ndjson
+
+# 2. For any issue worth a closer look, fetch the full issue record.
+sentire events get-issue myorg <issue-id> \
+  --fields id,shortId,title,culprit,metadata,firstSeen,lastSeen,count,userCount,status,assignedTo
+```
+
+Pick candidates from step 1 by sorting on `userCount` then `count`. Step 2
+returns assignment and timing context that is not present in the list view.
+
+### Workflow 2: Inspect a Sentry URL pasted from Slack or email
+
+Goal: get from a notification link to a complete stack trace in one call.
+
+```bash
+# 1. Resolve the URL straight to the recommended event (full debugging payload).
+sentire inspect "https://myorg.sentry.io/issues/123456789/" \
+  --fields id,eventID,title,culprit,platform,dateCreated,tags,entries,contexts
+
+# 2. If the recommended event is not enough, fall back to the issue's other
+#    events ordered by recency.
+sentire events list-issue myorg 123456789 \
+  --fields id,eventID,dateCreated,message,tags \
+  --format ndjson
+```
+
+`entries` contains the exception(s), stack frames, and breadcrumbs. `contexts`
+contains browser/OS/runtime/device data. Both are large — request them only
+when you actually need them.
+
+### Workflow 3: Build a release/environment report
+
+Goal: summarise recent error volume for a specific project and environment.
+
+```bash
+# 1. Confirm the project exists and capture its slug + platform.
+sentire projects get myorg my-project \
+  --fields slug,name,platform,status
+
+# 2. Pull issues affecting production in the last 24h.
+sentire events list-issues myorg \
+  --query "is:unresolved environment:production" \
+  --period 24h \
+  --project <project-id> \
+  --fields id,shortId,title,level,count,userCount,lastSeen \
+  --format ndjson
+
+# 3. Pull organisation-wide usage stats for the same window for context.
+sentire org stats myorg --period 24h
+```
+
+Use `--format ndjson` so the agent can stream-process one issue per line
+without holding the full array in memory.
 
 ## Error Handling
 
@@ -125,8 +229,10 @@ Errors are structured JSON when using `--format json` (default):
 
 ## Tips for AI Agents
 
-1. Use `sentire describe` to discover available commands and their output schemas
-2. Use `--fields` to request only the fields you need — Sentry events can be very large
-3. Use `--format ndjson` for streaming line-by-line processing
-4. Check exit codes for error classification instead of parsing messages
-5. All output goes to stdout, errors go to stderr
+1. Start with `sentire describe` to discover commands and their output schemas.
+2. Use `--fields` to request only the fields you need — Sentry events can be very large.
+3. Use `--format ndjson` for streaming line-by-line processing.
+4. Prefer JSON/NDJSON for parsing; `table`/`text`/`markdown` are for humans.
+5. Check exit codes for error classification instead of parsing messages.
+6. All output goes to stdout, errors go to stderr.
+7. The configured token is automatically redacted from error and verbose output, but tokens passed inside arguments (e.g. embedded in a URL) cannot be redacted — keep them out of arguments.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ sentire events get-issue <organization> <issue-id>
 sentire events get-issue-event <organization> <issue-id> latest
 ```
 
+### Agent Workflows
+
+Sentire is designed to be driven by both humans and AI agents. The `context`
+command prints an agent-oriented guide (also embedded as
+[`CONTEXT.md`](CONTEXT.md)) covering authentication, output control, query
+syntax, and end-to-end workflows for issue triage, URL inspection, and
+release reporting:
+
+```bash
+# Print the agent guide
+sentire context
+
+# Discover commands and their JSON output schema
+sentire describe
+sentire describe events list-issues
+```
+
+For machine consumption, prefer `--format json` (default) or `--format ndjson`
+together with `--fields` to keep payloads small. The `table`, `text`, and
+`markdown` formats are intended for humans and are not stable for parsing.
+
 ### URL Inspection
 
 Sentire includes a special `inspect` command that can parse Sentry URLs directly:

--- a/internal/cli/context_content.md
+++ b/internal/cli/context_content.md
@@ -69,6 +69,10 @@ Default output is JSON. Available formats: `json`, `ndjson`, `table`, `text`, `m
 sentire events list-issues myorg --format ndjson
 ```
 
+For agent pipelines, prefer `json` (default) or `ndjson`. The `table`, `text`,
+and `markdown` formats are intended for humans and may change formatting
+between releases — do not parse them.
+
 ### Field Filtering
 
 Use `--fields` to limit JSON output to specific fields — reduces token usage:
@@ -78,6 +82,11 @@ sentire events list-issues myorg --fields id,title,status,lastSeen
 sentire events get-issue myorg 12345 --fields id,title,count,userCount
 ```
 
+Field names match the top-level JSON keys returned by Sentry. Run
+`sentire describe <command>` to see the supported `output_fields` for each
+command before composing a `--fields` list — unknown names are silently
+dropped, so check first.
+
 ### Pagination
 
 Use `--all` to fetch all pages:
@@ -85,6 +94,25 @@ Use `--all` to fetch all pages:
 ```bash
 sentire events list-issues myorg --all
 ```
+
+`--all` follows cursor-based pagination until exhausted, which can return
+large amounts of data. For exploration, omit `--all` and use `--limit` plus
+`--fields` first; only enable `--all` when you genuinely need every page.
+
+### Query Filters
+
+The `--query` flag on `events list-issues` and `events list-issue` accepts
+Sentry's search syntax. Common, safe building blocks:
+
+- `is:unresolved`, `is:resolved`, `is:ignored`
+- `issue.priority:[high,medium]`
+- `level:error`, `level:warning`
+- `environment:production`
+- `firstSeen:-24h`, `lastSeen:-7d`
+- `assigned:me`, `assigned:#team-slug`
+
+Combine terms with spaces (implicit AND). Always quote the full value when
+it contains spaces or brackets so the shell does not split it.
 
 ## Schema Introspection
 
@@ -97,6 +125,82 @@ sentire describe
 # Describe a specific command
 sentire describe events list-issues
 ```
+
+The `describe` output schema is stable — each command entry exposes `name`,
+`description`, `args`, `flags`, and `output_fields`. Agents can rely on these
+keys when generating subsequent invocations.
+
+## Agent Workflows
+
+The following recipes show end-to-end flows an agent can run without any
+human input. Each step uses only stable JSON output and exit codes for
+control flow.
+
+### Workflow 1: Triage unresolved issues for an organization
+
+Goal: produce a short, ranked list of issues that deserve attention this
+week.
+
+```bash
+# 1. Pull the top unresolved high/medium priority issues from the last 7 days,
+#    keep only the fields needed for ranking.
+sentire events list-issues myorg \
+  --query "is:unresolved issue.priority:[high,medium]" \
+  --period 7d \
+  --fields id,shortId,title,level,count,userCount,lastSeen,permalink \
+  --format ndjson
+
+# 2. For any issue worth a closer look, fetch the full issue record.
+sentire events get-issue myorg <issue-id> \
+  --fields id,shortId,title,culprit,metadata,firstSeen,lastSeen,count,userCount,status,assignedTo
+```
+
+Pick candidates from step 1 by sorting on `userCount` then `count`. Step 2
+returns assignment and timing context that is not present in the list view.
+
+### Workflow 2: Inspect a Sentry URL pasted from Slack or email
+
+Goal: get from a notification link to a complete stack trace in one call.
+
+```bash
+# 1. Resolve the URL straight to the recommended event (full debugging payload).
+sentire inspect "https://myorg.sentry.io/issues/123456789/" \
+  --fields id,eventID,title,culprit,platform,dateCreated,tags,entries,contexts
+
+# 2. If the recommended event is not enough, fall back to the issue's other
+#    events ordered by recency.
+sentire events list-issue myorg 123456789 \
+  --fields id,eventID,dateCreated,message,tags \
+  --format ndjson
+```
+
+`entries` contains the exception(s), stack frames, and breadcrumbs. `contexts`
+contains browser/OS/runtime/device data. Both are large — request them only
+when you actually need them.
+
+### Workflow 3: Build a release/environment report
+
+Goal: summarise recent error volume for a specific project and environment.
+
+```bash
+# 1. Confirm the project exists and capture its slug + platform.
+sentire projects get myorg my-project \
+  --fields slug,name,platform,status
+
+# 2. Pull issues affecting production in the last 24h.
+sentire events list-issues myorg \
+  --query "is:unresolved environment:production" \
+  --period 24h \
+  --project <project-id> \
+  --fields id,shortId,title,level,count,userCount,lastSeen \
+  --format ndjson
+
+# 3. Pull organisation-wide usage stats for the same window for context.
+sentire org stats myorg --period 24h
+```
+
+Use `--format ndjson` so the agent can stream-process one issue per line
+without holding the full array in memory.
 
 ## Error Handling
 
@@ -125,8 +229,10 @@ Errors are structured JSON when using `--format json` (default):
 
 ## Tips for AI Agents
 
-1. Use `sentire describe` to discover available commands and their output schemas
-2. Use `--fields` to request only the fields you need — Sentry events can be very large
-3. Use `--format ndjson` for streaming line-by-line processing
-4. Check exit codes for error classification instead of parsing messages
-5. All output goes to stdout, errors go to stderr
+1. Start with `sentire describe` to discover commands and their output schemas.
+2. Use `--fields` to request only the fields you need — Sentry events can be very large.
+3. Use `--format ndjson` for streaming line-by-line processing.
+4. Prefer JSON/NDJSON for parsing; `table`/`text`/`markdown` are for humans.
+5. Check exit codes for error classification instead of parsing messages.
+6. All output goes to stdout, errors go to stderr.
+7. The configured token is automatically redacted from error and verbose output, but tokens passed inside arguments (e.g. embedded in a URL) cannot be redacted — keep them out of arguments.

--- a/tests/context_test.go
+++ b/tests/context_test.go
@@ -1,0 +1,31 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContextCommandPrintsAgentGuide(t *testing.T) {
+	binary := buildSentire(t)
+	stdout, stderr, exitCode := runSentire(t, binary, "context")
+
+	if exitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nstderr: %s", exitCode, stderr)
+	}
+
+	required := []string{
+		"# Sentire — Agent Context",
+		"## Agent Workflows",
+		"### Workflow 1: Triage unresolved issues for an organization",
+		"### Workflow 2: Inspect a Sentry URL pasted from Slack or email",
+		"### Workflow 3: Build a release/environment report",
+		"## Schema Introspection",
+		"## Error Handling",
+		"### Query Filters",
+	}
+	for _, marker := range required {
+		if !strings.Contains(stdout, marker) {
+			t.Errorf("Expected context output to contain %q", marker)
+		}
+	}
+}

--- a/tests/describe_test.go
+++ b/tests/describe_test.go
@@ -98,6 +98,55 @@ func TestDescribeSpecificCommand(t *testing.T) {
 	}
 }
 
+func TestDescribeSchemaIsStable(t *testing.T) {
+	binary := buildSentire(t)
+	stdout, _, exitCode := runSentire(t, binary, "describe")
+
+	if exitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d", exitCode)
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &top); err != nil {
+		t.Fatalf("Invalid JSON output: %v", err)
+	}
+	if _, ok := top["commands"]; !ok {
+		t.Fatal("Expected top-level 'commands' key")
+	}
+
+	var entries []map[string]json.RawMessage
+	if err := json.Unmarshal(top["commands"], &entries); err != nil {
+		t.Fatalf("Invalid commands array: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("Expected at least one command entry")
+	}
+
+	requiredKeys := []string{"name", "description"}
+	for _, entry := range entries {
+		for _, key := range requiredKeys {
+			if _, ok := entry[key]; !ok {
+				t.Errorf("Command entry missing %q: %v", key, entry)
+			}
+		}
+	}
+
+	stdout, _, exitCode = runSentire(t, binary, "describe", "events", "list-issues")
+	if exitCode != 0 {
+		t.Fatalf("Expected exit code 0 for specific command, got %d", exitCode)
+	}
+
+	var specific map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &specific); err != nil {
+		t.Fatalf("Invalid JSON output for specific command: %v", err)
+	}
+	for _, key := range []string{"name", "description", "args", "flags", "output_fields"} {
+		if _, ok := specific[key]; !ok {
+			t.Errorf("Specific describe output missing %q", key)
+		}
+	}
+}
+
 func TestDescribeUnknownCommand(t *testing.T) {
 	binary := buildSentire(t)
 


### PR DESCRIPTION
## Summary
- Expands the embedded `sentire context` guide (and mirrored `CONTEXT.md`) with practical agent workflow recipes for issue triage, Sentry URL inspection, and release/environment reporting, plus a query-filter cheat sheet and notes on which output formats are safe to parse.
- References the agent workflow path from the README so humans land on `sentire context` and `sentire describe`.
- Locks the `describe` JSON schema and the agent guide structure with new tests so the machine-readable surface can't silently drift.
- Adds an `Unreleased` block to `CHANGELOG.md` summarising everything merged since `v0.3.0` (token redaction, public module path, cobra bump, Go version matrix, this change).

Closes #20.

## Test plan
- [x] `make fmt`
- [x] `make test` (full suite, including new `TestContextCommandPrintsAgentGuide` and `TestDescribeSchemaIsStable`)
- [ ] Spot-check `sentire context` output renders the new Agent Workflows section
- [ ] Spot-check `sentire describe events list-issues` still returns stable `name/description/args/flags/output_fields` keys