### PR TITLE
docs: add changelog update workflow for user-visible changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- One or two sentences describing the change and why it is needed. -->
+
+## Changelog
+
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (see `AGENTS.md` → Changelog).
+- [ ] Not user-visible — no changelog entry needed (briefly explain below).
+
+<!-- If you ticked the second box, replace this with one line on why this
+change does not affect commands, output, packaging, config, shipped
+dependencies, or the `describe` / `context` agent contracts. -->
+
+## Test plan
+
+<!-- Commands you ran (e.g. `make test`) and any manual verification. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,42 @@ All commands output JSON by default with proper indentation. The `inspect` comma
 
 Commands follow the pattern: `./sentire <resource> <action> [args] [flags]` with the exception of the custom `inspect` command which prioritizes ease of use over API consistency.
 
+## Changelog
+
+`CHANGELOG.md` is the canonical record of user-visible changes. Update it in
+the same change that introduces the behaviour — not as a follow-up.
+
+### When to add an entry
+
+Add an entry when a change affects any of:
+
+- CLI surface (new/renamed/removed commands, flags, arguments, defaults)
+- Observable behaviour (output shape, exit codes, error messages, env vars)
+- Packaging or installation (release artifacts, Homebrew tap, `go install` path)
+- Configuration file format or supported locations
+- Dependency bumps that ship in the binary or change the minimum Go version
+- Agent-facing contracts: `describe` schema, `context` output, CONTEXT.md guidance
+
+Skip the changelog only for changes with no user-visible effect: internal
+refactors, test-only changes, CI tweaks that do not ship, formatting, or
+edits to private agent instructions (AGENTS.md / .opencode/).
+
+### How to add an entry
+
+- Add the entry under `## [Unreleased]` at the top of `CHANGELOG.md`. Do not
+  invent a new version heading — the release workflow promotes `[Unreleased]`
+  when the version is bumped.
+- Use the existing subsections: `Added`, `Changed`, `Fixed`, `Technical`.
+  Create a subsection only if it is missing and your change needs it.
+- Keep entries to a single line each. Lead with the user-facing effect, not
+  the implementation detail. Reference the command or flag explicitly when
+  relevant (e.g. ``Add `--all` flag to `events list-issues```).
+- Group related changes into one entry rather than splitting per-commit.
+
+Before opening a PR, check that `CHANGELOG.md` has an `[Unreleased]` entry
+covering your change, or be ready to explain in the PR why no entry is
+needed.
+
 ## New release
 
 When asked to create a new release please refer to @.opencode/agent/new-release.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Sentire will be documented in this file.
 - Agent workflow recipes in `context` output and `CONTEXT.md` (triage, URL inspection, release reporting)
 - README section pointing agents at `sentire context` and `sentire describe`
 - Test coverage locking the `describe` output schema and the agent context guide
+- Contributor and agent guidance for keeping `CHANGELOG.md` updated, plus a PR template prompting for an `[Unreleased]` entry
 
 ### Fixed
 - Redact `SENTRY_API_TOKEN` from error and verbose output

--- a/README.md
+++ b/README.md
@@ -356,6 +356,18 @@ To bypass the hook temporarily (not recommended):
 git commit --no-verify
 ```
 
+## Changelog
+
+User-visible changes are tracked in [`CHANGELOG.md`](CHANGELOG.md). When you
+open a PR, add an entry under `## [Unreleased]` for any change that affects
+commands, flags, output, packaging, configuration, dependencies that ship in
+the binary, or the agent-facing `describe` / `context` contracts. Pure
+internal refactors, tests, and CI tweaks do not need an entry.
+
+Use the existing `Added` / `Changed` / `Fixed` / `Technical` subsections and
+keep each entry to a single line that leads with the user-facing effect. See
+`AGENTS.md` for the full workflow.
+
 ## Testing
 
 Run the test suite:


### PR DESCRIPTION
## Summary

- Add a `Changelog` section to `AGENTS.md` documenting when a change must update `CHANGELOG.md` (CLI surface, observable behaviour, packaging, configuration, shipped dependencies, agent-facing `describe` / `context` contracts), when it can be skipped, and how to add the entry (single line under `## [Unreleased]`, existing Added/Changed/Fixed/Technical subsections, no new version heading).
- Add a short `Changelog` section to `README.md` so human contributors see the workflow alongside the rest of the Development Setup, with a pointer to `AGENTS.md` for the full rules.
- Add `.github/pull_request_template.md` with a Changelog checklist that forces PR authors to either confirm an `[Unreleased]` entry or explain why one is not needed.
- Dogfood the rule by adding an `[Unreleased]` entry for this change in `CHANGELOG.md`.

## Changelog

- [x] `CHANGELOG.md` updated under `## [Unreleased]` (see `AGENTS.md` → Changelog).
- [ ] Not user-visible — no changelog entry needed.

## Test plan

- [x] `make test`

Closes #26