### PR TITLE
Add context-aware HTTP requests and timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Sentire will be documented in this file.
 - README section pointing agents at `sentire context` and `sentire describe`
 - Test coverage locking the `describe` output schema and the agent context guide
 - Contributor and agent guidance for keeping `CHANGELOG.md` updated, plus a PR template prompting for an `[Unreleased]` entry
+- `Ctrl+C` (SIGINT) and SIGTERM cancel in-flight API requests, reported with a `canceled` error code
+
+### Changed
+- Request timeouts surface a clear `timeout` error code instead of a generic transport failure
 
 ### Fixed
 - Redact `SENTRY_API_TOKEN` from error and verbose output
@@ -17,6 +21,7 @@ All notable changes to Sentire will be documented in this file.
 - Use full GitHub module path (`github.com/andreagrandi/sentire`) for public `go install`
 - Bump `github.com/spf13/cobra` from 1.8.1 to 1.10.2
 - Lower `go.mod` minimum to Go 1.24 and add Go 1.24/1.25 to the CI build matrix
+- API requests use context-aware HTTP request creation, propagating cancellation and deadlines from CLI commands into the client
 
 ## [0.3.0] - 2026-03-07
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -217,7 +217,7 @@ Errors are structured JSON when using `--format json` (default):
 | 0 | Success |
 | 1 | General/unknown error |
 | 2 | Authentication error (missing or invalid token) |
-| 3 | API error (4xx/5xx from Sentry) |
+| 3 | API error (4xx/5xx from Sentry), request timeout, or cancellation |
 | 4 | Invalid input (bad slug, ID, URL, or format) |
 
 ### Error Codes
@@ -226,6 +226,8 @@ Errors are structured JSON when using `--format json` (default):
 - `api_error` — Sentry API returned an error
 - `invalid_input` — Bad argument (malformed slug, ID, or URL)
 - `invalid_format` — Unsupported output format
+- `timeout` — Request exceeded the timeout before completing
+- `canceled` — Request canceled before completing (e.g. Ctrl+C)
 
 ## Tips for AI Agents
 

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"github.com/andreagrandi/sentire/internal/client"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -28,7 +29,7 @@ type ListProjectEventsOptions struct {
 }
 
 // ListProjectEvents retrieves events for a specific project
-func (e *EventsAPI) ListProjectEvents(orgSlug, projectSlug string, opts *ListProjectEventsOptions) ([]models.Event, *client.PaginationInfo, error) {
+func (e *EventsAPI) ListProjectEvents(ctx context.Context, orgSlug, projectSlug string, opts *ListProjectEventsOptions) ([]models.Event, *client.PaginationInfo, error) {
 	endpoint := fmt.Sprintf("/projects/%s/%s/events/", orgSlug, projectSlug)
 
 	params := url.Values{}
@@ -53,7 +54,7 @@ func (e *EventsAPI) ListProjectEvents(orgSlug, projectSlug string, opts *ListPro
 		}
 	}
 
-	resp, err := e.client.Get(endpoint, params)
+	resp, err := e.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,7 +80,7 @@ type ListIssueEventsOptions struct {
 }
 
 // ListIssueEvents retrieves events for a specific issue
-func (e *EventsAPI) ListIssueEvents(orgSlug string, issueID string, opts *ListIssueEventsOptions) ([]models.Event, *client.PaginationInfo, error) {
+func (e *EventsAPI) ListIssueEvents(ctx context.Context, orgSlug string, issueID string, opts *ListIssueEventsOptions) ([]models.Event, *client.PaginationInfo, error) {
 	endpoint := fmt.Sprintf("/organizations/%s/issues/%s/events/", orgSlug, issueID)
 
 	params := url.Values{}
@@ -110,7 +111,7 @@ func (e *EventsAPI) ListIssueEvents(orgSlug string, issueID string, opts *ListIs
 		}
 	}
 
-	resp, err := e.client.Get(endpoint, params)
+	resp, err := e.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -137,7 +138,7 @@ type ListIssuesOptions struct {
 }
 
 // ListIssues retrieves issues for an organization
-func (e *EventsAPI) ListIssues(orgSlug string, opts *ListIssuesOptions) ([]models.Issue, *client.PaginationInfo, error) {
+func (e *EventsAPI) ListIssues(ctx context.Context, orgSlug string, opts *ListIssuesOptions) ([]models.Issue, *client.PaginationInfo, error) {
 	endpoint := fmt.Sprintf("/organizations/%s/issues/", orgSlug)
 
 	params := url.Values{}
@@ -171,7 +172,7 @@ func (e *EventsAPI) ListIssues(orgSlug string, opts *ListIssuesOptions) ([]model
 		}
 	}
 
-	resp, err := e.client.Get(endpoint, params)
+	resp, err := e.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -185,10 +186,10 @@ func (e *EventsAPI) ListIssues(orgSlug string, opts *ListIssuesOptions) ([]model
 }
 
 // GetProjectEvent retrieves a specific event for a project
-func (e *EventsAPI) GetProjectEvent(orgSlug, projectSlug, eventID string) (*models.Event, error) {
+func (e *EventsAPI) GetProjectEvent(ctx context.Context, orgSlug, projectSlug, eventID string) (*models.Event, error) {
 	endpoint := fmt.Sprintf("/projects/%s/%s/events/%s/", orgSlug, projectSlug, eventID)
 
-	resp, err := e.client.Get(endpoint, nil)
+	resp, err := e.client.Get(ctx, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -202,10 +203,10 @@ func (e *EventsAPI) GetProjectEvent(orgSlug, projectSlug, eventID string) (*mode
 }
 
 // GetIssue retrieves a specific issue
-func (e *EventsAPI) GetIssue(orgSlug, issueID string) (*models.Issue, error) {
+func (e *EventsAPI) GetIssue(ctx context.Context, orgSlug, issueID string) (*models.Issue, error) {
 	endpoint := fmt.Sprintf("/organizations/%s/issues/%s/", orgSlug, issueID)
 
-	resp, err := e.client.Get(endpoint, nil)
+	resp, err := e.client.Get(ctx, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +225,7 @@ type GetIssueEventOptions struct {
 }
 
 // GetIssueEvent retrieves a specific event for an issue
-func (e *EventsAPI) GetIssueEvent(orgSlug, issueID, eventID string, opts *GetIssueEventOptions) (*models.Event, error) {
+func (e *EventsAPI) GetIssueEvent(ctx context.Context, orgSlug, issueID, eventID string, opts *GetIssueEventOptions) (*models.Event, error) {
 	endpoint := fmt.Sprintf("/organizations/%s/issues/%s/events/%s/", orgSlug, issueID, eventID)
 
 	params := url.Values{}
@@ -234,7 +235,7 @@ func (e *EventsAPI) GetIssueEvent(orgSlug, issueID, eventID string, opts *GetIss
 		}
 	}
 
-	resp, err := e.client.Get(endpoint, params)
+	resp, err := e.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/organizations.go
+++ b/internal/api/organizations.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"github.com/andreagrandi/sentire/internal/client"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -23,7 +24,7 @@ type ListProjectsOptions struct {
 }
 
 // ListProjects retrieves projects for an organization
-func (o *OrganizationsAPI) ListProjects(orgSlug string, opts *ListProjectsOptions) ([]models.Project, *client.PaginationInfo, error) {
+func (o *OrganizationsAPI) ListProjects(ctx context.Context, orgSlug string, opts *ListProjectsOptions) ([]models.Project, *client.PaginationInfo, error) {
 	endpoint := fmt.Sprintf("/organizations/%s/projects/", orgSlug)
 
 	params := url.Values{}
@@ -31,7 +32,7 @@ func (o *OrganizationsAPI) ListProjects(orgSlug string, opts *ListProjectsOption
 		params.Set("cursor", opts.Cursor)
 	}
 
-	resp, err := o.client.Get(endpoint, params)
+	resp, err := o.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -59,7 +60,7 @@ type GetStatsOptions struct {
 }
 
 // GetStats retrieves event statistics for an organization
-func (o *OrganizationsAPI) GetStats(orgSlug string, opts *GetStatsOptions) (*models.OrganizationStats, error) {
+func (o *OrganizationsAPI) GetStats(ctx context.Context, orgSlug string, opts *GetStatsOptions) (*models.OrganizationStats, error) {
 	if opts == nil || opts.Field == "" {
 		return nil, fmt.Errorf("field parameter is required")
 	}
@@ -97,7 +98,7 @@ func (o *OrganizationsAPI) GetStats(orgSlug string, opts *GetStatsOptions) (*mod
 		params.Set("download", "true")
 	}
 
-	resp, err := o.client.Get(endpoint, params)
+	resp, err := o.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"github.com/andreagrandi/sentire/internal/client"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -23,7 +24,7 @@ type ListAllProjectsOptions struct {
 }
 
 // ListProjects retrieves all projects the user has access to
-func (p *ProjectsAPI) ListProjects(opts *ListAllProjectsOptions) ([]models.Project, *client.PaginationInfo, error) {
+func (p *ProjectsAPI) ListProjects(ctx context.Context, opts *ListAllProjectsOptions) ([]models.Project, *client.PaginationInfo, error) {
 	endpoint := "/projects/"
 
 	params := url.Values{}
@@ -31,7 +32,7 @@ func (p *ProjectsAPI) ListProjects(opts *ListAllProjectsOptions) ([]models.Proje
 		params.Set("cursor", opts.Cursor)
 	}
 
-	resp, err := p.client.Get(endpoint, params)
+	resp, err := p.client.Get(ctx, endpoint, params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,10 +46,10 @@ func (p *ProjectsAPI) ListProjects(opts *ListAllProjectsOptions) ([]models.Proje
 }
 
 // GetProject retrieves a specific project
-func (p *ProjectsAPI) GetProject(orgSlug, projectSlug string) (*models.Project, error) {
+func (p *ProjectsAPI) GetProject(ctx context.Context, orgSlug, projectSlug string) (*models.Project, error) {
 	endpoint := fmt.Sprintf("/projects/%s/%s/", orgSlug, projectSlug)
 
-	resp, err := p.client.Get(endpoint, nil)
+	resp, err := p.client.Get(ctx, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/context_content.md
+++ b/internal/cli/context_content.md
@@ -217,7 +217,7 @@ Errors are structured JSON when using `--format json` (default):
 | 0 | Success |
 | 1 | General/unknown error |
 | 2 | Authentication error (missing or invalid token) |
-| 3 | API error (4xx/5xx from Sentry) |
+| 3 | API error (4xx/5xx from Sentry), request timeout, or cancellation |
 | 4 | Invalid input (bad slug, ID, URL, or format) |
 
 ### Error Codes
@@ -226,6 +226,8 @@ Errors are structured JSON when using `--format json` (default):
 - `api_error` — Sentry API returned an error
 - `invalid_input` — Bad argument (malformed slug, ID, or URL)
 - `invalid_format` — Unsupported output format
+- `timeout` — Request exceeded the timeout before completing
+- `canceled` — Request canceled before completing (e.g. Ctrl+C)
 
 ## Tips for AI Agents
 

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -28,6 +28,8 @@ const (
 	CodeAPIError      = "api_error"
 	CodeInvalidInput  = "invalid_input"
 	CodeInvalidFormat = "invalid_format"
+	CodeTimeout       = "timeout"
+	CodeCanceled      = "canceled"
 )
 
 // CLIError represents a structured error with a machine-readable code
@@ -77,6 +79,24 @@ func NewInvalidFormatError(message string) *CLIError {
 	}
 }
 
+// NewTimeoutError creates a request timeout error
+func NewTimeoutError(message string) *CLIError {
+	return &CLIError{
+		Message:  message,
+		Code:     CodeTimeout,
+		ExitCode: ExitAPI,
+	}
+}
+
+// NewCanceledError creates a request cancellation error
+func NewCanceledError(message string) *CLIError {
+	return &CLIError{
+		Message:  message,
+		Code:     CodeCanceled,
+		ExitCode: ExitAPI,
+	}
+}
+
 // wrapError converts known error types into CLIError
 func wrapError(err error) error {
 	if err == nil {
@@ -88,6 +108,17 @@ func wrapError(err error) error {
 	var authErr *config.AuthError
 	if errors.As(err, &authErr) {
 		return NewAuthError(authErr.Message)
+	}
+	var reqErr *client.RequestError
+	if errors.As(err, &reqErr) {
+		if reqErr.Timeout {
+			return NewTimeoutError(reqErr.Message)
+		}
+		if reqErr.Canceled {
+			return NewCanceledError(reqErr.Message)
+		}
+		// Other transport failures keep the general exit code, matching
+		// the behavior before request errors were typed.
 	}
 	var apiErr *client.APIError
 	if errors.As(err, &apiErr) {

--- a/internal/cli/errors_request_test.go
+++ b/internal/cli/errors_request_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/andreagrandi/sentire/internal/client"
+)
+
+func TestWrapErrorTimeout(t *testing.T) {
+	err := wrapError(&client.RequestError{Message: "request timed out", Timeout: true})
+
+	cliErr, ok := err.(*CLIError)
+	if !ok {
+		t.Fatalf("Expected *CLIError, got %T", err)
+	}
+	if cliErr.Code != CodeTimeout {
+		t.Errorf("Expected code %q, got %q", CodeTimeout, cliErr.Code)
+	}
+	if cliErr.ExitCode != ExitAPI {
+		t.Errorf("Expected exit code %d, got %d", ExitAPI, cliErr.ExitCode)
+	}
+}
+
+func TestWrapErrorCanceled(t *testing.T) {
+	err := wrapError(&client.RequestError{Message: "request canceled", Canceled: true})
+
+	cliErr, ok := err.(*CLIError)
+	if !ok {
+		t.Fatalf("Expected *CLIError, got %T", err)
+	}
+	if cliErr.Code != CodeCanceled {
+		t.Errorf("Expected code %q, got %q", CodeCanceled, cliErr.Code)
+	}
+	if cliErr.ExitCode != ExitAPI {
+		t.Errorf("Expected exit code %d, got %d", ExitAPI, cliErr.ExitCode)
+	}
+}
+
+func TestWrapErrorGenericRequestError(t *testing.T) {
+	// A transport failure that is neither a timeout nor a cancellation keeps
+	// the general exit code, matching behavior before request errors were typed.
+	reqErr := &client.RequestError{Message: "http request failed: connection refused"}
+
+	err := wrapError(reqErr)
+	if _, ok := err.(*CLIError); ok {
+		t.Error("Expected a generic request error not to be wrapped as a CLIError")
+	}
+	if got := exitCodeFromError(err); got != ExitGeneral {
+		t.Errorf("Expected exit code %d, got %d", ExitGeneral, got)
+	}
+}

--- a/internal/cli/events.go
+++ b/internal/cli/events.go
@@ -149,7 +149,7 @@ func runListProjectEvents(cmd *cobra.Command, args []string) error {
 			opts.Cursor = cursor
 		}
 
-		events, pagination, err := eventsAPI.ListProjectEvents(orgSlug, projectSlug, opts)
+		events, pagination, err := eventsAPI.ListProjectEvents(cmd.Context(), orgSlug, projectSlug, opts)
 		if err != nil {
 			return err
 		}
@@ -217,7 +217,7 @@ func runListIssueEvents(cmd *cobra.Command, args []string) error {
 			opts.Cursor = cursor
 		}
 
-		events, pagination, err := eventsAPI.ListIssueEvents(orgSlug, issueID, opts)
+		events, pagination, err := eventsAPI.ListIssueEvents(cmd.Context(), orgSlug, issueID, opts)
 		if err != nil {
 			return err
 		}
@@ -285,7 +285,7 @@ func runListIssues(cmd *cobra.Command, args []string) error {
 			opts.Cursor = cursor
 		}
 
-		issues, pagination, err := eventsAPI.ListIssues(orgSlug, opts)
+		issues, pagination, err := eventsAPI.ListIssues(cmd.Context(), orgSlug, opts)
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func runGetEvent(cmd *cobra.Command, args []string) error {
 	}
 
 	eventsAPI := api.NewEventsAPI(c)
-	event, err := eventsAPI.GetProjectEvent(orgSlug, projectSlug, eventID)
+	event, err := eventsAPI.GetProjectEvent(cmd.Context(), orgSlug, projectSlug, eventID)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func runGetIssue(cmd *cobra.Command, args []string) error {
 	}
 
 	eventsAPI := api.NewEventsAPI(c)
-	issue, err := eventsAPI.GetIssue(orgSlug, issueID)
+	issue, err := eventsAPI.GetIssue(cmd.Context(), orgSlug, issueID)
 	if err != nil {
 		return err
 	}
@@ -379,7 +379,7 @@ func runGetIssueEvent(cmd *cobra.Command, args []string) error {
 		opts.Environment = environments
 	}
 
-	event, err := eventsAPI.GetIssueEvent(orgSlug, issueID, eventID, opts)
+	event, err := eventsAPI.GetIssueEvent(cmd.Context(), orgSlug, issueID, eventID, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -85,7 +85,7 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	eventsAPI := api.NewEventsAPI(c)
 
 	// Get the recommended event for the issue
-	event, err := eventsAPI.GetIssueEvent(parts.Organization, parts.IssueID, "recommended", nil)
+	event, err := eventsAPI.GetIssueEvent(cmd.Context(), parts.Organization, parts.IssueID, "recommended", nil)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve issue event: %w", err)
 	}

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -77,7 +77,7 @@ func runListOrgProjects(cmd *cobra.Command, args []string) error {
 			opts.Cursor = cursor
 		}
 
-		projects, pagination, err := orgAPI.ListProjects(orgSlug, opts)
+		projects, pagination, err := orgAPI.ListProjects(cmd.Context(), orgSlug, opts)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func runGetOrgStats(cmd *cobra.Command, args []string) error {
 		opts.Download = true
 	}
 
-	stats, err := orgAPI.GetStats(orgSlug, opts)
+	stats, err := orgAPI.GetStats(cmd.Context(), orgSlug, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -59,7 +59,7 @@ func runListProjects(cmd *cobra.Command, args []string) error {
 			opts.Cursor = cursor
 		}
 
-		projects, pagination, err := projectsAPI.ListProjects(opts)
+		projects, pagination, err := projectsAPI.ListProjects(cmd.Context(), opts)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func runGetProject(cmd *cobra.Command, args []string) error {
 	}
 
 	projectsAPI := api.NewProjectsAPI(c)
-	project, err := projectsAPI.GetProject(orgSlug, projectSlug)
+	project, err := projectsAPI.GetProject(cmd.Context(), orgSlug, projectSlug)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/andreagrandi/sentire/internal/version"
 	"github.com/spf13/cobra"
@@ -20,9 +23,13 @@ Before using sentire, make sure to set your Sentry API token:
 	SilenceErrors: true,
 }
 
-// Execute runs the root command
+// Execute runs the root command. The command context is canceled on SIGINT
+// (Ctrl+C) or SIGTERM so in-flight API requests stop promptly.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		format, _ := rootCmd.PersistentFlags().GetString("format")
 		writeErrorOutput(os.Stderr, err, format)
 		os.Exit(exitCodeFromError(err))

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/andreagrandi/sentire/internal/config"
 	"github.com/andreagrandi/sentire/internal/redact"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +19,11 @@ import (
 const (
 	BaseURL   = "https://sentry.io/api/0"
 	UserAgent = "sentire/1.0.0"
+
+	// DefaultTimeout bounds a single API request, including reading the
+	// response body. It applies to every command unless the caller's
+	// context carries an earlier deadline.
+	DefaultTimeout = 30 * time.Second
 )
 
 // Client represents the Sentry API client
@@ -59,6 +67,49 @@ func (e *APIError) Error() string {
 	return e.Message
 }
 
+// RequestError represents a transport-level request failure. Timeout and
+// Canceled distinguish the two cases the CLI reports specially; both are
+// false for other transport failures (DNS, connection refused, etc.).
+type RequestError struct {
+	Message  string
+	Timeout  bool
+	Canceled bool
+}
+
+func (e *RequestError) Error() string {
+	return e.Message
+}
+
+// requestErrorIfContext classifies err as a timeout or cancellation when it
+// originates from a context deadline, a context cancellation, or any other
+// network timeout. It returns nil when err is none of these.
+func requestErrorIfContext(err error) *RequestError {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return &RequestError{Message: "request canceled", Canceled: true}
+	case errors.Is(err, context.DeadlineExceeded):
+		return &RequestError{Message: "request timed out", Timeout: true}
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &RequestError{Message: "request timed out", Timeout: true}
+	}
+
+	return nil
+}
+
+// classifyRequestError converts a transport error from the HTTP client into a
+// RequestError, separating timeouts and cancellations from other failures.
+func classifyRequestError(err error, token string) *RequestError {
+	if reqErr := requestErrorIfContext(err); reqErr != nil {
+		return reqErr
+	}
+	// Transport errors come from net/http and may include the request URL;
+	// strip the token defensively in case it ever surfaces in a wrapped error.
+	return &RequestError{Message: fmt.Sprintf("http request failed: %s", redact.Secret(err.Error(), token))}
+}
+
 // NewClient creates a new Sentry API client
 func NewClient() (*Client, error) {
 	cfg, err := config.LoadConfig()
@@ -69,7 +120,7 @@ func NewClient() (*Client, error) {
 	return &Client{
 		BaseURL: BaseURL,
 		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: DefaultTimeout,
 		},
 		Token:     cfg.SentryAPIToken,
 		RateLimit: &RateLimiter{},
@@ -85,9 +136,7 @@ func (c *Client) Do(req *http.Request) (*Response, error) {
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		// Transport errors come from net/http and may include the request URL;
-		// strip the token defensively in case it ever surfaces in a wrapped error.
-		return nil, fmt.Errorf("http request failed: %s", redact.Secret(err.Error(), c.Token))
+		return nil, classifyRequestError(err, c.Token)
 	}
 
 	// Parse rate limit headers
@@ -114,14 +163,19 @@ func (c *Client) Do(req *http.Request) (*Response, error) {
 	return response, nil
 }
 
-// Get performs a GET request
-func (c *Client) Get(endpoint string, params url.Values) (*Response, error) {
+// Get performs a context-aware GET request. The context propagates
+// cancellation and any deadline from the caller into the HTTP request.
+func (c *Client) Get(ctx context.Context, endpoint string, params url.Values) (*Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	fullURL := c.BaseURL + endpoint
 	if params != nil {
 		fullURL += "?" + params.Encode()
 	}
 
-	req, err := http.NewRequest("GET", fullURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -134,6 +188,11 @@ func (c *Client) DecodeJSON(resp *Response, v interface{}) error {
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		// A timeout or cancellation while streaming the body surfaces here
+		// rather than from Do; report it as the request error it is.
+		if reqErr := requestErrorIfContext(err); reqErr != nil {
+			return reqErr
+		}
 		return fmt.Errorf("failed to decode JSON response: %w", err)
 	}
 

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"github.com/andreagrandi/sentire/internal/client"
 	"net/http"
 	"net/http/httptest"
@@ -149,7 +150,7 @@ func TestClientGet(t *testing.T) {
 	params := url.Values{}
 	params.Set("test", "value")
 
-	resp, err := c.Get("/test", params)
+	resp, err := c.Get(context.Background(), "/test", params)
 	if err != nil {
 		t.Fatalf("GET request failed: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestClientError(t *testing.T) {
 
 	c.BaseURL = server.URL
 
-	_, err = c.Get("/test", nil)
+	_, err = c.Get(context.Background(), "/test", nil)
 	if err == nil {
 		t.Error("Expected error for 400 response")
 	}
@@ -205,7 +206,7 @@ func TestDecodeJSON(t *testing.T) {
 
 	c.BaseURL = server.URL
 
-	resp, err := c.Get("/test", nil)
+	resp, err := c.Get(context.Background(), "/test", nil)
 	if err != nil {
 		t.Fatalf("GET request failed: %v", err)
 	}

--- a/tests/comprehensive_event_test.go
+++ b/tests/comprehensive_event_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/andreagrandi/sentire/internal/api"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -161,7 +162,7 @@ func TestCompleteEventData(t *testing.T) {
 
 	eventsAPI := api.NewEventsAPI(c)
 
-	event, err := eventsAPI.GetProjectEvent("test-org", "test-project", "complete-event-123")
+	event, err := eventsAPI.GetProjectEvent(context.Background(), "test-org", "test-project", "complete-event-123")
 	if err != nil {
 		t.Fatalf("GetProjectEvent failed: %v", err)
 	}

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/andreagrandi/sentire/internal/api"
 	"github.com/andreagrandi/sentire/internal/client"
@@ -68,7 +69,7 @@ func TestListProjectEvents(t *testing.T) {
 		Full:        true,
 	}
 
-	events, pagination, err := eventsAPI.ListProjectEvents("test-org", "test-project", opts)
+	events, pagination, err := eventsAPI.ListProjectEvents(context.Background(), "test-org", "test-project", opts)
 	if err != nil {
 		t.Fatalf("ListProjectEvents failed: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestListIssueEvents(t *testing.T) {
 		Query:       "test query",
 	}
 
-	events, _, err := eventsAPI.ListIssueEvents("test-org", "123", opts)
+	events, _, err := eventsAPI.ListIssueEvents(context.Background(), "test-org", "123", opts)
 	if err != nil {
 		t.Fatalf("ListIssueEvents failed: %v", err)
 	}
@@ -172,7 +173,7 @@ func TestListIssues(t *testing.T) {
 		Limit: 50,
 	}
 
-	issues, _, err := eventsAPI.ListIssues("test-org", opts)
+	issues, _, err := eventsAPI.ListIssues(context.Background(), "test-org", opts)
 	if err != nil {
 		t.Fatalf("ListIssues failed: %v", err)
 	}
@@ -209,7 +210,7 @@ func TestGetProjectEvent(t *testing.T) {
 
 	eventsAPI := api.NewEventsAPI(c)
 
-	event, err := eventsAPI.GetProjectEvent("test-org", "test-project", "event123")
+	event, err := eventsAPI.GetProjectEvent(context.Background(), "test-org", "test-project", "event123")
 	if err != nil {
 		t.Fatalf("GetProjectEvent failed: %v", err)
 	}
@@ -246,7 +247,7 @@ func TestGetIssue(t *testing.T) {
 
 	eventsAPI := api.NewEventsAPI(c)
 
-	issue, err := eventsAPI.GetIssue("test-org", "issue123")
+	issue, err := eventsAPI.GetIssue(context.Background(), "test-org", "issue123")
 	if err != nil {
 		t.Fatalf("GetIssue failed: %v", err)
 	}
@@ -290,7 +291,7 @@ func TestGetIssueEvent(t *testing.T) {
 		Environment: []string{"production"},
 	}
 
-	event, err := eventsAPI.GetIssueEvent("test-org", "issue123", "latest", opts)
+	event, err := eventsAPI.GetIssueEvent(context.Background(), "test-org", "issue123", "latest", opts)
 	if err != nil {
 		t.Fatalf("GetIssueEvent failed: %v", err)
 	}

--- a/tests/inspect_test.go
+++ b/tests/inspect_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/andreagrandi/sentire/internal/api"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -139,7 +140,7 @@ func TestInspectCommandIntegration(t *testing.T) {
 	// Test that the inspect logic would work
 	// (We can't easily test the CLI command directly in this test framework,
 	// but we can test the underlying API call it makes)
-	event, err := eventsAPI.GetIssueEvent("laterpay", "6796439331", "recommended", nil)
+	event, err := eventsAPI.GetIssueEvent(context.Background(), "laterpay", "6796439331", "recommended", nil)
 	if err != nil {
 		t.Fatalf("GetIssueEvent failed: %v", err)
 	}

--- a/tests/organizations_test.go
+++ b/tests/organizations_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/andreagrandi/sentire/internal/api"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -57,7 +58,7 @@ func TestListOrgProjects(t *testing.T) {
 		Cursor: "test-cursor",
 	}
 
-	projects, pagination, err := orgAPI.ListProjects("test-org", opts)
+	projects, pagination, err := orgAPI.ListProjects(context.Background(), "test-org", opts)
 	if err != nil {
 		t.Fatalf("ListProjects failed: %v", err)
 	}
@@ -162,7 +163,7 @@ func TestGetOrgStats(t *testing.T) {
 		Project:     []string{"1", "2"},
 	}
 
-	stats, err := orgAPI.GetStats("test-org", opts)
+	stats, err := orgAPI.GetStats(context.Background(), "test-org", opts)
 	if err != nil {
 		t.Fatalf("GetStats failed: %v", err)
 	}
@@ -195,14 +196,14 @@ func TestGetStatsWithoutField(t *testing.T) {
 	orgAPI := api.NewOrganizationsAPI(c)
 
 	// Test with nil options
-	_, err := orgAPI.GetStats("test-org", nil)
+	_, err := orgAPI.GetStats(context.Background(), "test-org", nil)
 	if err == nil {
 		t.Error("Expected error when opts is nil")
 	}
 
 	// Test with empty field
 	opts := &api.GetStatsOptions{}
-	_, err = orgAPI.GetStats("test-org", opts)
+	_, err = orgAPI.GetStats(context.Background(), "test-org", opts)
 	if err == nil {
 		t.Error("Expected error when field is empty")
 	}

--- a/tests/projects_test.go
+++ b/tests/projects_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/andreagrandi/sentire/internal/api"
 	"github.com/andreagrandi/sentire/pkg/models"
@@ -61,7 +62,7 @@ func TestListAllProjects(t *testing.T) {
 		Cursor: "test-cursor",
 	}
 
-	projects, pagination, err := projectsAPI.ListProjects(opts)
+	projects, pagination, err := projectsAPI.ListProjects(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("ListProjects failed: %v", err)
 	}
@@ -115,7 +116,7 @@ func TestListAllProjectsWithNilOptions(t *testing.T) {
 
 	projectsAPI := api.NewProjectsAPI(c)
 
-	projects, _, err := projectsAPI.ListProjects(nil)
+	projects, _, err := projectsAPI.ListProjects(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ListProjects failed: %v", err)
 	}
@@ -168,7 +169,7 @@ func TestGetProject(t *testing.T) {
 
 	projectsAPI := api.NewProjectsAPI(c)
 
-	project, err := projectsAPI.GetProject("test-org", "test-project")
+	project, err := projectsAPI.GetProject(context.Background(), "test-org", "test-project")
 	if err != nil {
 		t.Fatalf("GetProject failed: %v", err)
 	}
@@ -224,7 +225,7 @@ func TestGetProjectNotFound(t *testing.T) {
 
 	projectsAPI := api.NewProjectsAPI(c)
 
-	_, err := projectsAPI.GetProject("nonexistent-org", "nonexistent-project")
+	_, err := projectsAPI.GetProject(context.Background(), "nonexistent-org", "nonexistent-project")
 	if err == nil {
 		t.Error("Expected error for 404 response")
 	}

--- a/tests/redact_test.go
+++ b/tests/redact_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -80,7 +81,7 @@ func TestClientAPIErrorRedactsTokenInBody(t *testing.T) {
 	}
 	c.BaseURL = server.URL
 
-	_, err = c.Get("/test", nil)
+	_, err = c.Get(context.Background(), "/test", nil)
 	if err == nil {
 		t.Fatal("Expected error for 401 response")
 	}
@@ -108,7 +109,7 @@ func TestClientTransportErrorRedactsToken(t *testing.T) {
 	}
 	c.BaseURL = "http://invalid.localhost.invalid/" + token
 
-	_, err = c.Get("/test", nil)
+	_, err = c.Get(context.Background(), "/test", nil)
 	if err == nil {
 		t.Fatal("Expected transport error for unreachable host")
 	}

--- a/tests/timeout_test.go
+++ b/tests/timeout_test.go
@@ -1,0 +1,181 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/andreagrandi/sentire/internal/client"
+)
+
+// hangingHandler blocks until the client gives up on the request, so a test
+// server never holds Close() open longer than the client itself waits.
+func hangingHandler(w http.ResponseWriter, r *http.Request) {
+	select {
+	case <-r.Context().Done():
+	case <-time.After(5 * time.Second):
+	}
+}
+
+func TestNewClientDefaultTimeout(t *testing.T) {
+	os.Setenv("SENTRY_API_TOKEN", "test-token")
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	c, err := client.NewClient()
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	if c.HTTPClient.Timeout != client.DefaultTimeout {
+		t.Errorf("Expected HTTP client timeout %s, got %s", client.DefaultTimeout, c.HTTPClient.Timeout)
+	}
+}
+
+func TestGetTimeoutViaContextDeadline(t *testing.T) {
+	c, server := setupTestClient(hangingHandler)
+	defer server.Close()
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Get(ctx, "/test", nil)
+	if err == nil {
+		t.Fatal("Expected timeout error, got nil")
+	}
+
+	var reqErr *client.RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("Expected *client.RequestError, got %T: %v", err, err)
+	}
+	if !reqErr.Timeout {
+		t.Errorf("Expected Timeout to be true, got %+v", reqErr)
+	}
+	if reqErr.Canceled {
+		t.Errorf("Expected Canceled to be false for a deadline, got %+v", reqErr)
+	}
+}
+
+func TestGetTimeoutViaClientTimeout(t *testing.T) {
+	c, server := setupTestClient(hangingHandler)
+	defer server.Close()
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	// The HTTP client's own timeout must surface as a request timeout too.
+	c.HTTPClient.Timeout = 50 * time.Millisecond
+
+	_, err := c.Get(context.Background(), "/test", nil)
+	if err == nil {
+		t.Fatal("Expected timeout error, got nil")
+	}
+
+	var reqErr *client.RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("Expected *client.RequestError, got %T: %v", err, err)
+	}
+	if !reqErr.Timeout {
+		t.Errorf("Expected Timeout to be true, got %+v", reqErr)
+	}
+}
+
+func TestGetCanceledBeforeRequest(t *testing.T) {
+	c, server := setupTestClient(hangingHandler)
+	defer server.Close()
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Get(ctx, "/test", nil)
+	if err == nil {
+		t.Fatal("Expected cancellation error, got nil")
+	}
+
+	var reqErr *client.RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("Expected *client.RequestError, got %T: %v", err, err)
+	}
+	if !reqErr.Canceled {
+		t.Errorf("Expected Canceled to be true, got %+v", reqErr)
+	}
+	if reqErr.Timeout {
+		t.Errorf("Expected Timeout to be false for a cancellation, got %+v", reqErr)
+	}
+}
+
+func TestGetCanceledMidRequest(t *testing.T) {
+	started := make(chan struct{})
+	c, server := setupTestClient(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	})
+	defer server.Close()
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	_, err := c.Get(ctx, "/test", nil)
+	if err == nil {
+		t.Fatal("Expected cancellation error, got nil")
+	}
+
+	var reqErr *client.RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("Expected *client.RequestError, got %T: %v", err, err)
+	}
+	if !reqErr.Canceled {
+		t.Errorf("Expected Canceled to be true, got %+v", reqErr)
+	}
+}
+
+func TestDecodeJSONTimeout(t *testing.T) {
+	c, server := setupTestClient(func(w http.ResponseWriter, r *http.Request) {
+		// Send headers and a partial body, then stall so the timeout fires
+		// while DecodeJSON is streaming the body.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		w.Write([]byte(`{"partial":`))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	})
+	defer server.Close()
+	defer os.Unsetenv("SENTRY_API_TOKEN")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	resp, err := c.Get(ctx, "/test", nil)
+	if err != nil {
+		t.Fatalf("Get failed before body read: %v", err)
+	}
+
+	var out map[string]interface{}
+	err = c.DecodeJSON(resp, &out)
+	if err == nil {
+		t.Fatal("Expected timeout error while decoding body, got nil")
+	}
+
+	var reqErr *client.RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("Expected *client.RequestError, got %T: %v", err, err)
+	}
+	if !reqErr.Timeout {
+		t.Errorf("Expected Timeout to be true, got %+v", reqErr)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #15.

API requests were created without propagated contexts, so cancellation
and timeout behavior were not represented consistently in the client
layer. This change threads `context.Context` from CLI commands through
the API layer into the HTTP client.

## Changes

- **Context-aware client**: `client.Get` takes a `context.Context` and
  builds requests with `http.NewRequestWithContext`. The 30s default
  timeout is kept as a named `DefaultTimeout` constant.
- **Context propagation**: all API methods accept `ctx` as their first
  parameter; every CLI handler threads `cmd.Context()` into its calls.
- **Cancellation**: `Execute` installs a `signal.NotifyContext` for
  SIGINT/SIGTERM, so `Ctrl+C` cancels in-flight requests.
- **Useful errors**: transport failures are classified into a typed
  `RequestError`; timeouts and cancellations are reported with new
  `timeout` and `canceled` error codes. Other transport failures keep
  their previous exit code.
- **Docs**: `CHANGELOG.md`, `CONTEXT.md`, and the embedded agent context
  guide document the new error codes.

## Testing

- New `tests/timeout_test.go` covers the default timeout, timeouts via
  context deadline and via `HTTPClient.Timeout`, pre-request and
  mid-request cancellation, and body-read timeouts.
- New `internal/cli/errors_request_test.go` covers the `wrapError`
  mapping for timeout, cancellation, and generic transport errors.
- Existing tests updated for the new signatures; `make test`, `go vet`,
  and the race detector all pass.

## Compatibility

Existing command behavior and output formats are unchanged. Generic
transport errors keep the general exit code; only timeout and
cancellation get the new structured codes (exit code 3).