### PR TITLE
Improve human-readable issue and event output for triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sentire will be documented in this file.
 
 ### Changed
 - Request timeouts surface a clear `timeout` error code instead of a generic transport failure
+- Issue lists (`table`, `text`, `markdown`) now show a `Priority` column and relative `Last Seen` times for faster incident triage
+- Event lists (`table`, `text`, `markdown`) show a relative `Created` time; single issue and event views append the relative time to absolute timestamps
 
 ### Fixed
 - Redact `SENTRY_API_TOKEN` from error and verbose output

--- a/README.md
+++ b/README.md
@@ -256,43 +256,57 @@ sentire org stats my-org --field="sum(quantity)" --period=7d --project=123 --pro
 sentire events list-issues my-org --environment=production --period=24h --format text
 ```
 
+### Incident triage workflow
+
+The `table`, `text`, and `markdown` formats are tuned for scanning incidents in
+a terminal. Issue lists surface **status**, **priority**, **event/user counts**,
+and a relative **last seen** time (e.g. `3h ago`); single issue and event views
+keep the absolute timestamp and add the relative time in parentheses.
+
+```bash
+# Scan unresolved high/medium priority issues from the last 7 days
+sentire events list-issues my-org \
+  --query="is:unresolved issue.priority:[high,medium]" --period=7d --format table
+
+# Drill into one issue with full timestamps
+sentire events get-issue my-org 123456789 --format text
+```
+
 ### Output Format Comparison
 
 **Table format** (great for terminal viewing):
 ```
-┌──────┬─────────────────────┬───────┬──────────┬─────────┬──────────────────┐
-│  ID  │        TITLE        │ LEVEL │ STATUS   │  COUNT  │   LAST SEEN      │
-├──────┼─────────────────────┼───────┼──────────┼─────────┼──────────────────┤
-│ 1234 │ TypeError in login  │ error │ unresov. │   45    │ 2025-08-30 10:15 │
-│ 1235 │ API timeout         │ warn  │ resolved │   12    │ 2025-08-30 09:30 │
-└──────┴─────────────────────┴───────┴──────────┴─────────┴──────────────────┘
+┌───────────┬──────────────────────────────┬─────────┬────────────┬──────────┬────────┬───────┬───────────┬─────────────┐
+│    ID     │            TITLE             │  LEVEL  │   STATUS   │ PRIORITY │ EVENTS │ USERS │ LAST SEEN │   PROJECT   │
+├───────────┼──────────────────────────────┼─────────┼────────────┼──────────┼────────┼───────┼───────────┼─────────────┤
+│ SENTIRE-1 │ TypeError in login component │ error   │ unresolved │ high     │ 45     │ 23    │ 3h ago    │ web-app     │
+│ SENTIRE-2 │ API timeout on user endpoint │ warning │ resolved   │ medium   │ 12     │ 8     │ 2d ago    │ api-service │
+└───────────┴──────────────────────────────┴─────────┴────────────┴──────────┴────────┴───────┴───────────┴─────────────┘
 ```
 
 **Text format** (simple and scriptable):
 ```
 Issues (2 total):
 
-1. Issue #1234
-   Title: TypeError in login component
-   Level: error | Status: unresolved | Count: 45
-   Project: web-app | Users: 23
-   Last Seen: 2025-08-30 10:15
+1. TypeError in login component
+   ID: SENTIRE-1 | Status: unresolved | Level: error | Priority: high
+   Events: 45 | Users: 23 | Last seen: 3h ago
+   Project: web-app
 
-2. Issue #1235
-   Title: API timeout on user endpoint
-   Level: warning | Status: resolved | Count: 12
-   Project: api-service | Users: 8
-   Last Seen: 2025-08-30 09:30
+2. API timeout on user endpoint
+   ID: SENTIRE-2 | Status: resolved | Level: warning | Priority: medium
+   Events: 12 | Users: 8 | Last seen: 2d ago
+   Project: api-service
 ```
 
 **Markdown format** (documentation-ready):
 ```markdown
 # Issues (2 total)
 
-| ID | Title | Level | Status | Count | Users | Last Seen | Project |
-|----|-------|-------|--------|-------|-------|-----------|---------|
-| 1234 | TypeError in login... | error | unresolved | 45 | 23 | 08-30 10:15 | web-app |
-| 1235 | API timeout on use... | warning | resolved | 12 | 8 | 08-30 09:30 | api-service |
+| ID | Title | Level | Status | Priority | Events | Users | Last Seen | Project |
+|----|-------|-------|--------|----------|--------|-------|-----------|---------|
+| SENTIRE-1 | TypeError in login component | error | unresolved | high | 45 | 23 | 3h ago | web-app |
+| SENTIRE-2 | API timeout on user endpoint | warning | resolved | medium | 12 | 8 | 2d ago | api-service |
 ```
 
 ## API Coverage

--- a/internal/cli/formatter/helpers.go
+++ b/internal/cli/formatter/helpers.go
@@ -1,6 +1,9 @@
 package formatter
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Helper functions shared across formatters
 
@@ -16,4 +19,55 @@ func formatTime(t *time.Time) string {
 		return ""
 	}
 	return t.Format("2006-01-02 15:04:05")
+}
+
+// humanizeDuration renders a duration as a short relative string.
+// Examples: "just now", "5m ago", "3h ago", "2d ago".
+func humanizeDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dw ago", int(d.Hours()/(24*7)))
+	case d < 365*24*time.Hour:
+		return fmt.Sprintf("%dmo ago", int(d.Hours()/(24*30)))
+	default:
+		return fmt.Sprintf("%dy ago", int(d.Hours()/(24*365)))
+	}
+}
+
+// relativeTime renders how long ago t occurred.
+// It returns an empty string for the zero time.
+func relativeTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return humanizeDuration(time.Since(t))
+}
+
+// formatTimestamp renders an absolute timestamp with a relative suffix.
+// Example: "2025-08-30 10:00:00 (3h ago)".
+func formatTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	abs := t.Format("2006-01-02 15:04:05")
+	if rel := relativeTime(t); rel != "" {
+		return abs + " (" + rel + ")"
+	}
+	return abs
+}
+
+// dashIfEmpty returns "-" when s is empty, keeping table columns aligned.
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }

--- a/internal/cli/formatter/helpers_test.go
+++ b/internal/cli/formatter/helpers_test.go
@@ -1,0 +1,69 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHumanizeDuration(t *testing.T) {
+	cases := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{"seconds", 30 * time.Second, "just now"},
+		{"minutes", 5 * time.Minute, "5m ago"},
+		{"hours", 3 * time.Hour, "3h ago"},
+		{"days", 2 * 24 * time.Hour, "2d ago"},
+		{"weeks", 3 * 7 * 24 * time.Hour, "3w ago"},
+		{"months", 60 * 24 * time.Hour, "2mo ago"},
+		{"years", 400 * 24 * time.Hour, "1y ago"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := humanizeDuration(tc.duration)
+			if got != tc.expected {
+				t.Errorf("humanizeDuration(%v) = %q, want %q", tc.duration, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRelativeTimeZeroValue(t *testing.T) {
+	if got := relativeTime(time.Time{}); got != "" {
+		t.Errorf("relativeTime(zero) = %q, want empty string", got)
+	}
+}
+
+func TestRelativeTimeRecent(t *testing.T) {
+	got := relativeTime(time.Now().Add(-2 * time.Hour))
+	if got != "2h ago" {
+		t.Errorf("relativeTime(2h back) = %q, want %q", got, "2h ago")
+	}
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	recent := time.Now().Add(-3 * time.Hour)
+	got := formatTimestamp(recent)
+	if !strings.Contains(got, "(3h ago)") {
+		t.Errorf("formatTimestamp = %q, want it to contain relative suffix", got)
+	}
+	if !strings.Contains(got, recent.Format("2006-01-02")) {
+		t.Errorf("formatTimestamp = %q, want it to contain absolute date", got)
+	}
+
+	if got := formatTimestamp(time.Time{}); got != "" {
+		t.Errorf("formatTimestamp(zero) = %q, want empty string", got)
+	}
+}
+
+func TestDashIfEmpty(t *testing.T) {
+	if got := dashIfEmpty(""); got != "-" {
+		t.Errorf("dashIfEmpty(\"\") = %q, want %q", got, "-")
+	}
+	if got := dashIfEmpty("high"); got != "high" {
+		t.Errorf("dashIfEmpty(\"high\") = %q, want %q", got, "high")
+	}
+}

--- a/internal/cli/formatter/markdown.go
+++ b/internal/cli/formatter/markdown.go
@@ -29,8 +29,8 @@ func (f *MarkdownFormatter) FormatEvent(event *models.Event) error {
 	fmt.Fprintf(f.writer, "**Type**: %s  \n", event.Type)
 	fmt.Fprintf(f.writer, "**Platform**: %s  \n", event.Platform)
 	fmt.Fprintf(f.writer, "**Project ID**: %s  \n", event.ProjectID)
-	fmt.Fprintf(f.writer, "**Date Created**: %s  \n", event.DateCreated.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(f.writer, "**Date Received**: %s  \n", event.DateReceived.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(f.writer, "**Date Created**: %s  \n", formatTimestamp(event.DateCreated))
+	fmt.Fprintf(f.writer, "**Date Received**: %s  \n", formatTimestamp(event.DateReceived))
 	fmt.Fprintf(f.writer, "**Size**: %d bytes  \n", event.Size)
 
 	if event.GroupID != "" {
@@ -72,18 +72,18 @@ func (f *MarkdownFormatter) FormatEvents(events []models.Event) error {
 	fmt.Fprintf(f.writer, "# Events (%d total)\n\n", len(events))
 
 	// Create markdown table
-	fmt.Fprintf(f.writer, "| ID | Title | Type | Platform | Project ID | Date | Environment |\n")
+	fmt.Fprintf(f.writer, "| ID | Title | Type | Platform | Project ID | Created | Environment |\n")
 	fmt.Fprintf(f.writer, "|----|----|----|----|----|----|----|\n")
 
 	for _, event := range events {
 		fmt.Fprintf(f.writer, "| %s | %s | %s | %s | %s | %s | %s |\n",
 			event.EventID,
-			escapeMarkdown(truncateString(event.Title, 20)),
+			escapeMarkdown(truncateString(event.Title, 40)),
 			event.Type,
 			event.Platform,
 			event.ProjectID,
-			event.DateCreated.Format("01-02 15:04"),
-			event.Environment)
+			dashIfEmpty(relativeTime(event.DateCreated)),
+			dashIfEmpty(event.Environment))
 	}
 
 	fmt.Fprintf(f.writer, "\n")
@@ -110,10 +110,10 @@ func (f *MarkdownFormatter) FormatIssue(issue *models.Issue) error {
 
 	fmt.Fprintf(f.writer, "**Platform**: %s  \n", issue.Platform)
 	fmt.Fprintf(f.writer, "**Project**: %s (%s)  \n", issue.Project.Name, issue.Project.Slug)
-	fmt.Fprintf(f.writer, "**Count**: %s  \n", issue.Count)
-	fmt.Fprintf(f.writer, "**User Count**: %d  \n", issue.UserCount)
-	fmt.Fprintf(f.writer, "**First Seen**: %s  \n", issue.FirstSeen.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(f.writer, "**Last Seen**: %s  \n", issue.LastSeen.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(f.writer, "**Events**: %s  \n", issue.Count)
+	fmt.Fprintf(f.writer, "**Users**: %d  \n", issue.UserCount)
+	fmt.Fprintf(f.writer, "**First Seen**: %s  \n", formatTimestamp(issue.FirstSeen))
+	fmt.Fprintf(f.writer, "**Last Seen**: %s  \n", formatTimestamp(issue.LastSeen))
 
 	if issue.Culprit != "" {
 		fmt.Fprintf(f.writer, "**Culprit**: %s  \n", issue.Culprit)
@@ -144,18 +144,19 @@ func (f *MarkdownFormatter) FormatIssues(issues []models.Issue) error {
 	fmt.Fprintf(f.writer, "# Issues (%d total)\n\n", len(issues))
 
 	// Create markdown table
-	fmt.Fprintf(f.writer, "| ID | Title | Level | Status | Count | Users | Last Seen | Project |\n")
-	fmt.Fprintf(f.writer, "|----|----|----|----|----|----|----|----|\n")
+	fmt.Fprintf(f.writer, "| ID | Title | Level | Status | Priority | Events | Users | Last Seen | Project |\n")
+	fmt.Fprintf(f.writer, "|----|----|----|----|----|----|----|----|----|\n")
 
 	for _, issue := range issues {
-		fmt.Fprintf(f.writer, "| %s | %s | %s | %s | %s | %d | %s | %s |\n",
+		fmt.Fprintf(f.writer, "| %s | %s | %s | %s | %s | %s | %d | %s | %s |\n",
 			issue.ShortID,
-			escapeMarkdown(truncateString(issue.Title, 25)),
+			escapeMarkdown(truncateString(issue.Title, 40)),
 			issue.Level,
 			issue.Status,
+			dashIfEmpty(issue.Priority),
 			issue.Count,
 			issue.UserCount,
-			issue.LastSeen.Format("01-02 15:04"),
+			dashIfEmpty(relativeTime(issue.LastSeen)),
 			issue.Project.Slug)
 	}
 

--- a/internal/cli/formatter/table.go
+++ b/internal/cli/formatter/table.go
@@ -33,8 +33,8 @@ func (f *TableFormatter) FormatEvent(event *models.Event) error {
 		{"Platform", event.Platform},
 		{"Type", event.Type},
 		{"Project ID", event.ProjectID},
-		{"Date Created", event.DateCreated.Format("2006-01-02 15:04:05")},
-		{"Date Received", event.DateReceived.Format("2006-01-02 15:04:05")},
+		{"Date Created", formatTimestamp(event.DateCreated)},
+		{"Date Received", formatTimestamp(event.DateReceived)},
 		{"Size", strconv.FormatInt(event.Size, 10)},
 	}
 
@@ -70,17 +70,17 @@ func (f *TableFormatter) FormatEvents(events []models.Event) error {
 	}
 
 	table := tablewriter.NewWriter(f.writer)
-	table.Header("ID", "Title", "Type", "Platform", "Project ID", "Date Created", "Environment")
+	table.Header("ID", "Title", "Type", "Platform", "Project ID", "Created", "Environment")
 
 	for _, event := range events {
 		row := []string{
 			event.EventID,
-			truncateString(event.Title, 30),
+			truncateString(event.Title, 40),
 			event.Type,
 			event.Platform,
 			event.ProjectID,
-			event.DateCreated.Format("2006-01-02 15:04"),
-			event.Environment,
+			dashIfEmpty(relativeTime(event.DateCreated)),
+			dashIfEmpty(event.Environment),
 		}
 		err := table.Append(row)
 		if err != nil {
@@ -105,10 +105,10 @@ func (f *TableFormatter) FormatIssue(issue *models.Issue) error {
 		{"Status", issue.Status},
 		{"Platform", issue.Platform},
 		{"Project", fmt.Sprintf("%s (%s)", issue.Project.Name, issue.Project.Slug)},
-		{"Count", issue.Count},
-		{"User Count", strconv.Itoa(issue.UserCount)},
-		{"First Seen", issue.FirstSeen.Format("2006-01-02 15:04:05")},
-		{"Last Seen", issue.LastSeen.Format("2006-01-02 15:04:05")},
+		{"Events", issue.Count},
+		{"Users", strconv.Itoa(issue.UserCount)},
+		{"First Seen", formatTimestamp(issue.FirstSeen)},
+		{"Last Seen", formatTimestamp(issue.LastSeen)},
 		{"Is Public", strconv.FormatBool(issue.IsPublic)},
 		{"Is Bookmarked", strconv.FormatBool(issue.IsBookmarked)},
 		{"Is Subscribed", strconv.FormatBool(issue.IsSubscribed)},
@@ -146,17 +146,18 @@ func (f *TableFormatter) FormatIssues(issues []models.Issue) error {
 	}
 
 	table := tablewriter.NewWriter(f.writer)
-	table.Header("ID", "Title", "Level", "Status", "Count", "User Count", "Last Seen", "Project")
+	table.Header("ID", "Title", "Level", "Status", "Priority", "Events", "Users", "Last Seen", "Project")
 
 	for _, issue := range issues {
 		row := []string{
 			issue.ShortID,
-			truncateString(issue.Title, 30),
+			truncateString(issue.Title, 40),
 			issue.Level,
 			issue.Status,
+			dashIfEmpty(issue.Priority),
 			issue.Count,
 			strconv.Itoa(issue.UserCount),
-			issue.LastSeen.Format("01-02 15:04"),
+			dashIfEmpty(relativeTime(issue.LastSeen)),
 			issue.Project.Slug,
 		}
 		err := table.Append(row)

--- a/internal/cli/formatter/text.go
+++ b/internal/cli/formatter/text.go
@@ -27,8 +27,8 @@ func (f *TextFormatter) FormatEvent(event *models.Event) error {
 	fmt.Fprintf(f.writer, "Type: %s\n", event.Type)
 	fmt.Fprintf(f.writer, "Platform: %s\n", event.Platform)
 	fmt.Fprintf(f.writer, "Project ID: %s\n", event.ProjectID)
-	fmt.Fprintf(f.writer, "Date Created: %s\n", event.DateCreated.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(f.writer, "Date Received: %s\n", event.DateReceived.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(f.writer, "Date Created: %s\n", formatTimestamp(event.DateCreated))
+	fmt.Fprintf(f.writer, "Date Received: %s\n", formatTimestamp(event.DateReceived))
 	fmt.Fprintf(f.writer, "Size: %d bytes\n", event.Size)
 
 	if event.GroupID != "" {
@@ -69,13 +69,18 @@ func (f *TextFormatter) FormatEvents(events []models.Event) error {
 	fmt.Fprintf(f.writer, "Events (%d total):\n\n", len(events))
 
 	for i, event := range events {
-		fmt.Fprintf(f.writer, "%d. Event #%s\n", i+1, event.EventID)
-		fmt.Fprintf(f.writer, "   Title: %s\n", event.Title)
-		fmt.Fprintf(f.writer, "   Type: %s | Platform: %s | Project ID: %s\n",
-			event.Type, event.Platform, event.ProjectID)
-		fmt.Fprintf(f.writer, "   Date: %s | Environment: %s\n",
-			event.DateCreated.Format("2006-01-02 15:04"), event.Environment)
-		fmt.Fprintf(f.writer, "\n")
+		fmt.Fprintf(f.writer, "%d. %s\n", i+1, event.Title)
+		fmt.Fprintf(f.writer, "   ID: %s | Type: %s | Platform: %s\n",
+			event.EventID, event.Type, event.Platform)
+
+		meta := fmt.Sprintf("Project ID: %s", event.ProjectID)
+		if event.Environment != "" {
+			meta += " | Environment: " + event.Environment
+		}
+		if rel := relativeTime(event.DateCreated); rel != "" {
+			meta += " | Created: " + rel
+		}
+		fmt.Fprintf(f.writer, "   %s\n\n", meta)
 	}
 
 	return nil
@@ -99,10 +104,10 @@ func (f *TextFormatter) FormatIssue(issue *models.Issue) error {
 
 	fmt.Fprintf(f.writer, "Platform: %s\n", issue.Platform)
 	fmt.Fprintf(f.writer, "Project: %s (%s)\n", issue.Project.Name, issue.Project.Slug)
-	fmt.Fprintf(f.writer, "Count: %s\n", issue.Count)
-	fmt.Fprintf(f.writer, "User Count: %d\n", issue.UserCount)
-	fmt.Fprintf(f.writer, "First Seen: %s\n", issue.FirstSeen.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(f.writer, "Last Seen: %s\n", issue.LastSeen.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(f.writer, "Events: %s\n", issue.Count)
+	fmt.Fprintf(f.writer, "Users: %d\n", issue.UserCount)
+	fmt.Fprintf(f.writer, "First Seen: %s\n", formatTimestamp(issue.FirstSeen))
+	fmt.Fprintf(f.writer, "Last Seen: %s\n", formatTimestamp(issue.LastSeen))
 
 	if issue.Culprit != "" {
 		fmt.Fprintf(f.writer, "Culprit: %s\n", issue.Culprit)
@@ -133,15 +138,22 @@ func (f *TextFormatter) FormatIssues(issues []models.Issue) error {
 	fmt.Fprintf(f.writer, "Issues (%d total):\n\n", len(issues))
 
 	for i, issue := range issues {
-		fmt.Fprintf(f.writer, "%d. Issue #%s\n", i+1, issue.ShortID)
-		fmt.Fprintf(f.writer, "   Title: %s\n", issue.Title)
-		fmt.Fprintf(f.writer, "   Level: %s | Status: %s | Count: %s\n",
-			issue.Level, issue.Status, issue.Count)
-		fmt.Fprintf(f.writer, "   Project: %s | Users: %d\n",
-			issue.Project.Slug, issue.UserCount)
-		fmt.Fprintf(f.writer, "   Last Seen: %s\n",
-			issue.LastSeen.Format("2006-01-02 15:04"))
-		fmt.Fprintf(f.writer, "\n")
+		fmt.Fprintf(f.writer, "%d. %s\n", i+1, issue.Title)
+
+		triage := fmt.Sprintf("ID: %s | Status: %s | Level: %s",
+			issue.ShortID, issue.Status, issue.Level)
+		if issue.Priority != "" {
+			triage += " | Priority: " + issue.Priority
+		}
+		fmt.Fprintf(f.writer, "   %s\n", triage)
+
+		counts := fmt.Sprintf("Events: %s | Users: %d", issue.Count, issue.UserCount)
+		if rel := relativeTime(issue.LastSeen); rel != "" {
+			counts += " | Last seen: " + rel
+		}
+		fmt.Fprintf(f.writer, "   %s\n", counts)
+
+		fmt.Fprintf(f.writer, "   Project: %s\n\n", issue.Project.Slug)
 	}
 
 	return nil

--- a/tests/triage_format_test.go
+++ b/tests/triage_format_test.go
@@ -1,0 +1,155 @@
+package tests
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andreagrandi/sentire/internal/cli/formatter"
+	"github.com/andreagrandi/sentire/pkg/models"
+)
+
+// triageIssues returns a fixed set of issues with recent timestamps so that
+// relative-time output is predictable.
+func triageIssues() []models.Issue {
+	now := time.Now()
+	return []models.Issue{
+		{
+			ID:        "issue-1",
+			ShortID:   "SENTIRE-1",
+			Title:     "TypeError in login component",
+			Level:     "error",
+			Status:    "unresolved",
+			Priority:  "high",
+			Project:   models.IssueProject{Name: "Web App", Slug: "web-app"},
+			Count:     "45",
+			UserCount: 23,
+			FirstSeen: now.Add(-5 * 24 * time.Hour),
+			LastSeen:  now.Add(-3 * time.Hour),
+		},
+		{
+			ID:        "issue-2",
+			ShortID:   "SENTIRE-2",
+			Title:     "API timeout on user endpoint",
+			Level:     "warning",
+			Status:    "resolved",
+			Project:   models.IssueProject{Name: "API Service", Slug: "api-service"},
+			Count:     "12",
+			UserCount: 8,
+			FirstSeen: now.Add(-10 * 24 * time.Hour),
+			LastSeen:  now.Add(-2 * 24 * time.Hour),
+		},
+	}
+}
+
+func renderIssues(t *testing.T, format string, issues []models.Issue) string {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := createTestCommand(format)
+	cmd.Flags().Set("format", format)
+
+	f, err := formatter.NewFormatter(cmd, &buf)
+	if err != nil {
+		t.Fatalf("Failed to create %s formatter: %v", format, err)
+	}
+	if err := f.FormatIssues(issues); err != nil {
+		t.Fatalf("Failed to format issues as %s: %v", format, err)
+	}
+	return buf.String()
+}
+
+// Issue lists must surface priority and relative last-seen times for triage.
+func TestFormatIssuesTriageFields(t *testing.T) {
+	issues := triageIssues()
+
+	for _, format := range []string{"table", "text", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			output := renderIssues(t, format, issues)
+
+			if !strings.Contains(strings.ToLower(output), "priority") {
+				t.Errorf("%s issue list missing priority column", format)
+			}
+			if !strings.Contains(output, "high") {
+				t.Errorf("%s issue list missing priority value", format)
+			}
+			if !strings.Contains(output, "3h ago") {
+				t.Errorf("%s issue list missing relative last-seen time", format)
+			}
+			if !strings.Contains(output, "2d ago") {
+				t.Errorf("%s issue list missing relative last-seen for second issue", format)
+			}
+		})
+	}
+}
+
+// A missing priority should render as a dash in the markdown list rather than
+// an empty, misaligned cell.
+func TestFormatIssuesEmptyPriorityRendersDash(t *testing.T) {
+	output := renderIssues(t, "markdown", triageIssues())
+	if !strings.Contains(output, "| - |") {
+		t.Errorf("markdown issue list should render '| - |' for missing priority")
+	}
+}
+
+// Single-issue views keep absolute timestamps but add a relative suffix.
+func TestFormatIssueTimestampHasRelativeSuffix(t *testing.T) {
+	issue := triageIssues()[0]
+
+	for _, format := range []string{"table", "text", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := createTestCommand(format)
+			cmd.Flags().Set("format", format)
+
+			f, err := formatter.NewFormatter(cmd, &buf)
+			if err != nil {
+				t.Fatalf("Failed to create %s formatter: %v", format, err)
+			}
+			if err := f.FormatIssue(&issue); err != nil {
+				t.Fatalf("Failed to format issue as %s: %v", format, err)
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, "(3h ago)") {
+				t.Errorf("%s issue view missing relative last-seen suffix", format)
+			}
+		})
+	}
+}
+
+// Event lists surface a relative creation time for quick scanning.
+func TestFormatEventsRelativeCreated(t *testing.T) {
+	events := []models.Event{
+		{
+			EventID:     "evt-1",
+			Title:       "First Error",
+			Type:        "error",
+			Platform:    "python",
+			ProjectID:   "project-1",
+			Environment: "production",
+			DateCreated: time.Now().Add(-4 * time.Hour),
+		},
+	}
+
+	for _, format := range []string{"table", "text", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := createTestCommand(format)
+			cmd.Flags().Set("format", format)
+
+			f, err := formatter.NewFormatter(cmd, &buf)
+			if err != nil {
+				t.Fatalf("Failed to create %s formatter: %v", format, err)
+			}
+			if err := f.FormatEvents(events); err != nil {
+				t.Fatalf("Failed to format events as %s: %v", format, err)
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, "4h ago") {
+				t.Errorf("%s event list missing relative creation time", format)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #19.

Issue and event lists in the `table`, `text`, and `markdown` formats were dense to scan when triaging incidents in a terminal. This makes status, priority, counts, and timestamps stand out, while leaving JSON/NDJSON output unchanged for scripts.

## Changes

**Shared helpers** (`internal/cli/formatter/helpers.go`)
- `humanizeDuration` / `relativeTime` — render durations as `3h ago`, `2d ago`, etc.
- `formatTimestamp` — absolute time plus a relative suffix: `2025-08-30 10:00:00 (3h ago)`
- `dashIfEmpty` — keeps table columns aligned when a value is missing

**Issue lists** (`table`, `text`, `markdown`)
- Added a **Priority** column/field — a core triage signal (the `list-issues` default query already filters on priority) previously only visible in single-issue views
- **Last Seen** now shows relative time for fast scanning
- Renamed `Count` / `User Count` to `Events` / `Users` for clarity
- In `text`, the title moves to the header line with triage fields grouped beneath it
- Title truncation widened to 40 chars

**Event lists** — added a relative `Created` column; title on the header line in `text`

**Single issue/event views** — `First Seen` / `Last Seen` / `Date Created` / `Date Received` keep the absolute timestamp and append the relative time

## Tests

- `internal/cli/formatter/helpers_test.go` — unit tests for the duration helpers
- `tests/triage_format_test.go` — covers priority columns, dash fallback, and relative timestamps across all three human-readable formats

## Docs

- `README.md` — refreshed the format comparison with accurate output and added an "Incident triage workflow" section
- `CHANGELOG.md` — entries under `[Unreleased]`

`make build`, `make fmt`, `make test`, and `go vet ./...` all pass.