### PR TITLE
Add mocked CLI integration tests for major command flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Sentire will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `SENTRY_API_BASE_URL` environment variable to target a self-hosted Sentry instance
 - Agent workflow recipes in `context` output and `CONTEXT.md` (triage, URL inspection, release reporting)
 - README section pointing agents at `sentire context` and `sentire describe`
 - Test coverage locking the `describe` output schema and the agent context guide

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ If both are provided, the environment variable takes precedence over the configu
 
 You can obtain an API token from your Sentry organization settings under "Auth Tokens".
 
+### API Base URL
+
+By default Sentire targets Sentry's hosted API at `https://sentry.io/api/0`. To
+use a self-hosted Sentry instance, point `SENTRY_API_BASE_URL` at its API root:
+
+```bash
+export SENTRY_API_BASE_URL=https://sentry.example.com/api/0
+```
+
+When unset, the hosted API is used.
+
 ### Token Safety in Output
 
 Sentire never prints the configured token in standard, verbose, or error

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -118,13 +119,24 @@ func NewClient() (*Client, error) {
 	}
 
 	return &Client{
-		BaseURL: BaseURL,
+		BaseURL: resolveBaseURL(),
 		HTTPClient: &http.Client{
 			Timeout: DefaultTimeout,
 		},
 		Token:     cfg.SentryAPIToken,
 		RateLimit: &RateLimiter{},
 	}, nil
+}
+
+// resolveBaseURL returns the API base URL. The SENTRY_API_BASE_URL environment
+// variable overrides the hosted default, so the CLI can target a self-hosted
+// Sentry instance or a local mock server. A trailing slash is trimmed so it
+// joins cleanly with endpoint paths.
+func resolveBaseURL() string {
+	if override := os.Getenv("SENTRY_API_BASE_URL"); override != "" {
+		return strings.TrimRight(override, "/")
+	}
+	return BaseURL
 }
 
 // Do executes an HTTP request and returns the response

--- a/tests/cli_helpers_test.go
+++ b/tests/cli_helpers_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sentireBinary is the path to the sentire binary built once for the whole test
+// package by TestMain. The CLI integration tests run it as a subprocess so they
+// exercise argument parsing, output formatting, and exit codes end to end.
+var sentireBinary string
+
+// emptyHomeDir is an empty directory used as HOME for CLI subprocesses so a real
+// ~/.config/sentire/config.json on the developer's machine never leaks into a
+// test run.
+var emptyHomeDir string
+
+// TestMain builds the sentire binary into a temporary directory before running
+// the package tests and removes it afterwards.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "sentire-cli-tests")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create temp dir:", err)
+		os.Exit(1)
+	}
+
+	sentireBinary = filepath.Join(dir, "sentire")
+	emptyHomeDir = filepath.Join(dir, "home")
+	if err := os.Mkdir(emptyHomeDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create home dir:", err)
+		os.RemoveAll(dir)
+		os.Exit(1)
+	}
+
+	build := exec.Command("go", "build", "-o", sentireBinary, "github.com/andreagrandi/sentire/cmd/sentire")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build sentire binary:", err)
+		os.RemoveAll(dir)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// cliResult captures the observable result of a sentire subprocess run.
+type cliResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+// testEnv builds a hermetic environment for a sentire subprocess. It drops any
+// SENTRY_API_* and HOME values inherited from the caller, points HOME at an
+// empty directory, and adds the token and base URL only when non-empty.
+func testEnv(baseURL, token string) []string {
+	var env []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "SENTRY_API_TOKEN=") ||
+			strings.HasPrefix(e, "SENTRY_API_BASE_URL=") ||
+			strings.HasPrefix(e, "HOME=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	env = append(env, "HOME="+emptyHomeDir)
+	if token != "" {
+		env = append(env, "SENTRY_API_TOKEN="+token)
+	}
+	if baseURL != "" {
+		env = append(env, "SENTRY_API_BASE_URL="+baseURL)
+	}
+	return env
+}
+
+// runCLIEnv runs the sentire binary with the given environment and arguments.
+func runCLIEnv(t *testing.T, env []string, args ...string) cliResult {
+	t.Helper()
+
+	cmd := exec.Command(sentireBinary, args...)
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	result := cliResult{}
+	if err := cmd.Run(); err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("failed to run sentire %v: %v", args, err)
+		}
+		result.exitCode = exitErr.ExitCode()
+	}
+	result.stdout = stdout.String()
+	result.stderr = stderr.String()
+	return result
+}
+
+// runCLI runs the sentire binary against a mock server with a valid test token.
+func runCLI(t *testing.T, baseURL string, args ...string) cliResult {
+	t.Helper()
+	return runCLIEnv(t, testEnv(baseURL, "test-token"), args...)
+}
+
+// mockServer starts an httptest server with handler and registers its shutdown.
+func mockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// writeJSON writes v as a JSON response body, failing the test on encoding errors.
+func writeJSON(t *testing.T, w http.ResponseWriter, v interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("failed to encode mock response: %v", err)
+	}
+}

--- a/tests/cli_integration_test.go
+++ b/tests/cli_integration_test.go
@@ -1,0 +1,517 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andreagrandi/sentire/pkg/models"
+)
+
+// decodeCLIJSON unmarshals stdout produced by a sentire command, failing the
+// test with the raw output when the payload is not valid JSON.
+func decodeCLIJSON(t *testing.T, output string, v interface{}) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(output), v); err != nil {
+		t.Fatalf("CLI output is not valid JSON: %v\noutput:\n%s", err, output)
+	}
+}
+
+// sampleIssues returns issues with recent timestamps so relative-time output is
+// stable across formats.
+func sampleIssues() []models.Issue {
+	now := time.Now()
+	return []models.Issue{
+		{
+			ID:        "issue-1",
+			ShortID:   "WEB-1",
+			Title:     "TypeError in checkout flow",
+			Level:     "error",
+			Status:    "unresolved",
+			Priority:  "high",
+			Project:   models.IssueProject{Name: "Web App", Slug: "web-app"},
+			Count:     "42",
+			UserCount: 17,
+			FirstSeen: now.Add(-6 * 24 * time.Hour),
+			LastSeen:  now.Add(-2 * time.Hour),
+		},
+		{
+			ID:        "issue-2",
+			ShortID:   "API-7",
+			Title:     "Timeout calling payments service",
+			Level:     "warning",
+			Status:    "unresolved",
+			Priority:  "medium",
+			Project:   models.IssueProject{Name: "API", Slug: "api"},
+			Count:     "9",
+			UserCount: 4,
+			FirstSeen: now.Add(-3 * 24 * time.Hour),
+			LastSeen:  now.Add(-30 * time.Minute),
+		},
+	}
+}
+
+// sampleEvent returns an event with debugging details for inspect/get flows.
+func sampleEvent() models.Event {
+	return models.Event{
+		ID:          "event-abc",
+		EventID:     "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+		Title:       "TypeError in checkout flow",
+		Message:     "Cannot read property 'total' of undefined",
+		Type:        "error",
+		Platform:    "javascript",
+		ProjectID:   "project-1",
+		Environment: "production",
+		Culprit:     "checkout.js",
+		DateCreated: time.Now().Add(-2 * time.Hour),
+	}
+}
+
+// --- Projects -------------------------------------------------------------
+
+func TestCLIProjectsList(t *testing.T) {
+	projects := []models.Project{
+		{ID: "p1", Slug: "web-app", Name: "Web App", Platform: "javascript"},
+		{ID: "p2", Slug: "api", Name: "API Service", Platform: "python"},
+	}
+
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/" {
+			t.Errorf("expected path /projects/, got %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("expected bearer test-token, got %q", auth)
+		}
+		writeJSON(t, w, projects)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		res := runCLI(t, server.URL, "projects", "list")
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		var got []models.Project
+		decodeCLIJSON(t, res.stdout, &got)
+		if len(got) != 2 || got[0].Slug != "web-app" || got[1].Slug != "api" {
+			t.Errorf("unexpected projects: %+v", got)
+		}
+	})
+
+	t.Run("table", func(t *testing.T) {
+		res := runCLI(t, server.URL, "projects", "list", "--format", "table")
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		if !strings.Contains(res.stdout, "Web App") || !strings.Contains(res.stdout, "API Service") {
+			t.Errorf("table output missing project names:\n%s", res.stdout)
+		}
+	})
+}
+
+func TestCLIProjectsGet(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/test-org/web-app/" {
+			t.Errorf("expected path /projects/test-org/web-app/, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, models.Project{ID: "p1", Slug: "web-app", Name: "Web App", Platform: "javascript"})
+	})
+
+	res := runCLI(t, server.URL, "projects", "get", "test-org", "web-app")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got models.Project
+	decodeCLIJSON(t, res.stdout, &got)
+	if got.Slug != "web-app" {
+		t.Errorf("expected slug web-app, got %s", got.Slug)
+	}
+}
+
+func TestCLIProjectsGetInvalidSlug(t *testing.T) {
+	// Validation rejects the slug before any HTTP request is attempted.
+	res := runCLI(t, "http://127.0.0.1:0", "projects", "get", "Test_Org", "web-app")
+	if res.exitCode != 4 {
+		t.Fatalf("expected exit 4 for invalid slug, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	assertErrorCode(t, res.stderr, "invalid_input")
+}
+
+// --- Organizations --------------------------------------------------------
+
+func TestCLIOrgListProjects(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/test-org/projects/" {
+			t.Errorf("expected org projects path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, []models.Project{{ID: "p1", Slug: "web-app", Name: "Web App"}})
+	})
+
+	res := runCLI(t, server.URL, "org", "list-projects", "test-org")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got []models.Project
+	decodeCLIJSON(t, res.stdout, &got)
+	if len(got) != 1 || got[0].Slug != "web-app" {
+		t.Errorf("unexpected projects: %+v", got)
+	}
+}
+
+func TestCLIOrgStats(t *testing.T) {
+	stats := models.OrganizationStats{
+		Start:    time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		End:      time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+		Projects: []models.ProjectStatsDetail{{ID: "p1", Slug: "web-app"}},
+	}
+	stats.Totals.Sum = 1000
+	stats.Totals.TimesSeen = 500
+
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/test-org/stats-summary/" {
+			t.Errorf("expected stats-summary path, got %s", r.URL.Path)
+		}
+		if field := r.URL.Query().Get("field"); field != "sum(quantity)" {
+			t.Errorf("expected default field sum(quantity), got %q", field)
+		}
+		writeJSON(t, w, stats)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		res := runCLI(t, server.URL, "org", "stats", "test-org")
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		var got models.OrganizationStats
+		decodeCLIJSON(t, res.stdout, &got)
+		if got.Totals.Sum != 1000 {
+			t.Errorf("expected total sum 1000, got %d", got.Totals.Sum)
+		}
+	})
+
+	t.Run("text", func(t *testing.T) {
+		res := runCLI(t, server.URL, "org", "stats", "test-org", "--format", "text")
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		if !strings.Contains(res.stdout, "1000") {
+			t.Errorf("text output missing total sum:\n%s", res.stdout)
+		}
+	})
+}
+
+// --- Events & Issues ------------------------------------------------------
+
+func TestCLIEventsListIssues(t *testing.T) {
+	issues := sampleIssues()
+
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/test-org/issues/" {
+			t.Errorf("expected issues path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, issues)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		res := runCLI(t, server.URL, "events", "list-issues", "test-org")
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		var got []models.Issue
+		decodeCLIJSON(t, res.stdout, &got)
+		if len(got) != 2 || got[0].ShortID != "WEB-1" {
+			t.Errorf("unexpected issues: %+v", got)
+		}
+	})
+
+	for _, format := range []string{"table", "text", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			res := runCLI(t, server.URL, "events", "list-issues", "test-org", "--format", format)
+			if res.exitCode != 0 {
+				t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+			}
+			if !strings.Contains(res.stdout, "TypeError in checkout flow") {
+				t.Errorf("%s output missing issue title:\n%s", format, res.stdout)
+			}
+			if !strings.Contains(strings.ToLower(res.stdout), "priority") {
+				t.Errorf("%s output missing priority column:\n%s", format, res.stdout)
+			}
+		})
+	}
+}
+
+func TestCLIEventsListIssuesPagination(t *testing.T) {
+	issues := sampleIssues()
+
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// The client only reads the cursor query param from the Link URL, so a
+		// fixed absolute URL is enough to drive the next page.
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			w.Header().Set("Link",
+				`<https://sentry.local/issues/?cursor=page2>; rel="next"; results="true"`)
+			writeJSON(t, w, issues[:1])
+		case "page2":
+			writeJSON(t, w, issues[1:])
+		default:
+			t.Errorf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	})
+
+	res := runCLI(t, server.URL, "events", "list-issues", "test-org", "--all")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got []models.Issue
+	decodeCLIJSON(t, res.stdout, &got)
+	if len(got) != 2 {
+		t.Errorf("expected 2 issues across pages, got %d", len(got))
+	}
+}
+
+func TestCLIEventsGetIssue(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/test-org/issues/123456/" {
+			t.Errorf("expected single issue path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, models.Issue{ID: "123456", ShortID: "WEB-1", Title: "TypeError in checkout flow"})
+	})
+
+	res := runCLI(t, server.URL, "events", "get-issue", "test-org", "123456")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got models.Issue
+	decodeCLIJSON(t, res.stdout, &got)
+	if got.ShortID != "WEB-1" {
+		t.Errorf("expected short ID WEB-1, got %s", got.ShortID)
+	}
+}
+
+func TestCLIEventsListProject(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/test-org/web-app/events/" {
+			t.Errorf("expected project events path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, []models.Event{sampleEvent()})
+	})
+
+	res := runCLI(t, server.URL, "events", "list-project", "test-org", "web-app")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got []models.Event
+	decodeCLIJSON(t, res.stdout, &got)
+	if len(got) != 1 || got[0].Title != "TypeError in checkout flow" {
+		t.Errorf("unexpected events: %+v", got)
+	}
+}
+
+func TestCLIEventsGetEvent(t *testing.T) {
+	eventID := "a1b2c3d4e5f60718293a4b5c6d7e8f90"
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/test-org/web-app/events/"+eventID+"/" {
+			t.Errorf("expected event detail path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, sampleEvent())
+	})
+
+	res := runCLI(t, server.URL, "events", "get-event", "test-org", "web-app", eventID)
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got models.Event
+	decodeCLIJSON(t, res.stdout, &got)
+	if got.EventID != eventID {
+		t.Errorf("expected event ID %s, got %s", eventID, got.EventID)
+	}
+}
+
+func TestCLIEventsGetIssueEvent(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/test-org/issues/123456/events/latest/" {
+			t.Errorf("expected issue event path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, sampleEvent())
+	})
+
+	res := runCLI(t, server.URL, "events", "get-issue-event", "test-org", "123456", "latest")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	var got models.Event
+	decodeCLIJSON(t, res.stdout, &got)
+	if got.Title != "TypeError in checkout flow" {
+		t.Errorf("unexpected event title: %s", got.Title)
+	}
+}
+
+// --- Inspect --------------------------------------------------------------
+
+func TestCLIInspect(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/laterpay/issues/6796439331/events/recommended/" {
+			t.Errorf("expected recommended event path, got %s", r.URL.Path)
+		}
+		writeJSON(t, w, sampleEvent())
+	})
+
+	url := "https://laterpay.sentry.io/issues/6796439331/?alert_type=issue"
+
+	t.Run("json", func(t *testing.T) {
+		res := runCLI(t, server.URL, "inspect", url)
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		var got models.Event
+		decodeCLIJSON(t, res.stdout, &got)
+		if got.Title != "TypeError in checkout flow" {
+			t.Errorf("unexpected event title: %s", got.Title)
+		}
+	})
+
+	t.Run("markdown", func(t *testing.T) {
+		res := runCLI(t, server.URL, "inspect", url, "--format", "markdown")
+		if res.exitCode != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+		}
+		if !strings.Contains(res.stdout, "# Event Details") {
+			t.Errorf("markdown output missing event header:\n%s", res.stdout)
+		}
+	})
+}
+
+func TestCLIInspectInvalidURL(t *testing.T) {
+	res := runCLI(t, "http://127.0.0.1:0", "inspect", "https://example.com/not-sentry")
+	if res.exitCode != 4 {
+		t.Fatalf("expected exit 4 for invalid URL, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	assertErrorCode(t, res.stderr, "invalid_input")
+}
+
+// --- Agent-facing commands ------------------------------------------------
+
+func TestCLIContext(t *testing.T) {
+	// context is self-contained and needs no API token.
+	res := runCLIEnv(t, testEnv("", ""), "context")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "# Sentire — Agent Context") {
+		t.Errorf("context output missing guide heading:\n%s", res.stdout)
+	}
+}
+
+func TestCLIDescribe(t *testing.T) {
+	res := runCLIEnv(t, testEnv("", ""), "describe")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+
+	var got struct {
+		Commands []struct {
+			Name string `json:"name"`
+		} `json:"commands"`
+	}
+	decodeCLIJSON(t, res.stdout, &got)
+
+	found := false
+	for _, c := range got.Commands {
+		if c.Name == "events list-issues" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("describe output missing 'events list-issues' command")
+	}
+}
+
+func TestCLIDescribeCommand(t *testing.T) {
+	res := runCLIEnv(t, testEnv("", ""), "describe", "events", "list-issues")
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+
+	var got struct {
+		Name         string   `json:"name"`
+		OutputFields []string `json:"output_fields"`
+	}
+	decodeCLIJSON(t, res.stdout, &got)
+	if got.Name != "events list-issues" {
+		t.Errorf("expected command name 'events list-issues', got %q", got.Name)
+	}
+	if len(got.OutputFields) == 0 {
+		t.Errorf("expected non-empty output_fields for events list-issues")
+	}
+}
+
+// --- Error handling -------------------------------------------------------
+
+func TestCLIAPIErrorJSON(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"detail":"internal server error"}`)
+	})
+
+	res := runCLI(t, server.URL, "events", "list-issues", "test-org")
+	if res.exitCode != 3 {
+		t.Fatalf("expected exit 3 for API error, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	assertErrorCode(t, res.stderr, "api_error")
+}
+
+func TestCLIAPIErrorHumanReadable(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"not found"}`)
+	})
+
+	res := runCLI(t, server.URL, "events", "list-issues", "test-org", "--format", "table")
+	if res.exitCode != 3 {
+		t.Fatalf("expected exit 3 for API error, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	if !strings.HasPrefix(res.stderr, "Error:") {
+		t.Errorf("expected human-readable error prefix, got: %s", res.stderr)
+	}
+}
+
+func TestCLIMissingToken(t *testing.T) {
+	// No token and an empty HOME means no config file is found either.
+	res := runCLIEnv(t, testEnv("", ""), "events", "list-issues", "test-org")
+	if res.exitCode != 2 {
+		t.Fatalf("expected exit 2 for missing token, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	assertErrorCode(t, res.stderr, "auth_missing")
+}
+
+func TestCLIUnsupportedFormat(t *testing.T) {
+	server := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, []models.Issue{})
+	})
+
+	res := runCLI(t, server.URL, "events", "list-issues", "test-org", "--format", "xml")
+	if res.exitCode != 4 {
+		t.Fatalf("expected exit 4 for unsupported format, got %d (stderr: %s)", res.exitCode, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "unsupported format: xml") {
+		t.Errorf("expected unsupported format message, got: %s", res.stderr)
+	}
+}
+
+// assertErrorCode checks that stderr carries a structured JSON error with the
+// expected machine-readable code.
+func assertErrorCode(t *testing.T, stderr, wantCode string) {
+	t.Helper()
+	var got struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal([]byte(stderr), &got); err != nil {
+		t.Fatalf("error output is not JSON: %v\nstderr:\n%s", err, stderr)
+	}
+	if got.Code != wantCode {
+		t.Errorf("expected error code %q, got %q (stderr: %s)", wantCode, got.Code, stderr)
+	}
+}

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -41,6 +41,32 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientBaseURLOverride(t *testing.T) {
+	t.Setenv("SENTRY_API_TOKEN", "test-token")
+
+	t.Run("override applied", func(t *testing.T) {
+		t.Setenv("SENTRY_API_BASE_URL", "https://sentry.example.com/api/0")
+		c, err := client.NewClient()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if c.BaseURL != "https://sentry.example.com/api/0" {
+			t.Errorf("Expected overridden base URL, got %s", c.BaseURL)
+		}
+	})
+
+	t.Run("trailing slash trimmed", func(t *testing.T) {
+		t.Setenv("SENTRY_API_BASE_URL", "https://sentry.example.com/api/0/")
+		c, err := client.NewClient()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if c.BaseURL != "https://sentry.example.com/api/0" {
+			t.Errorf("Expected trailing slash trimmed, got %s", c.BaseURL)
+		}
+	})
+}
+
 func TestClientDo(t *testing.T) {
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Closes #23.

Adds CLI-level integration tests that exercise the major command flows end
to end against local mocked Sentry API responses, verifying output formats
and error handling.

## Test seam

The CLI commands build their HTTP client internally with a hard-coded base
URL, so there was no way to point them at a mock server. `NewClient` now
honors an optional `SENTRY_API_BASE_URL` environment variable. This doubles
as a user-facing feature: it enables targeting a self-hosted Sentry instance.

## Tests

All new tests are subprocess-based — a real `sentire` binary is built once in
`TestMain` and run as a child process, so they exercise argument parsing,
output formatting, and exit codes exactly as a user would. Each subprocess
runs in a hermetic environment (stripped `SENTRY_API_*`, empty `HOME`) so no
real credentials or config file can leak into a run.

- `tests/cli_helpers_test.go` — `TestMain` binary build and shared helpers.
- `tests/cli_integration_test.go` — command flows against `httptest` mocks:
  - `projects list`/`get`, `org list-projects`/`stats`, all `events`
    subcommands, `inspect`, `context`, `describe`
  - JSON and human-readable (`table`/`text`/`markdown`) output
  - `--all` cursor pagination across two pages
  - Error handling with exit codes: API error, missing token, invalid
    input, unsupported format — including the structured JSON error code
  - Mock handlers assert request paths and the `Authorization` header
- `tests/client_test.go` — `TestNewClientBaseURLOverride` unit test.

## Acceptance criteria

- [x] Major command flows have CLI-level coverage
- [x] Tests run without real Sentry credentials
- [x] JSON and human-readable outputs are covered

## Notes

`TestMain` adds a one-time `go build` (~1s) to `go test ./tests/`.

## Changelog

`SENTRY_API_BASE_URL` documented under `[Unreleased]` in `CHANGELOG.md` and
in the README Configuration section.