### PR TITLE
Add make vet target and CI vet check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Run tests
       run: make test
 
+    - name: Run vet
+      run: make vet
+
     - name: Run fmt check
       run: |
         if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sentire will be documented in this file.
 - Bump `github.com/spf13/cobra` from 1.8.1 to 1.10.2
 - Lower `go.mod` minimum to Go 1.24 and add Go 1.24/1.25 to the CI build matrix
 - API requests use context-aware HTTP request creation, propagating cancellation and deadlines from CLI commands into the client
+- Add `make vet` target and CI step running `go vet ./...`
 
 ## [0.3.0] - 2026-03-07
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean install help
+.PHONY: build test clean install help vet
 
 # Default target
 all: build
@@ -53,6 +53,11 @@ lint:
 	@echo "Linting code..."
 	@golangci-lint run
 
+# Run go vet static analysis
+vet:
+	@echo "Running go vet..."
+	@go vet ./...
+
 # Install the binary to GOPATH/bin
 install: build
 	@echo "Installing sentire..."
@@ -77,6 +82,7 @@ help:
 	@echo "  clean         - Remove build artifacts"
 	@echo "  deps          - Install dependencies"
 	@echo "  fmt           - Format code"
+	@echo "  vet           - Run go vet static analysis"
 	@echo "  lint          - Lint code (requires golangci-lint)"
 	@echo "  install       - Install binary to GOPATH/bin"
 	@echo "  help          - Show this help message"


### PR DESCRIPTION
## Summary
- Add `vet` target to the Makefile that runs `go vet ./...`
- Add a `Run vet` step in CI right after the test step so it runs across the full Go matrix
- Note the change under `[Unreleased] → Technical` in `CHANGELOG.md`

## Test plan
- [x] `make vet` runs and passes locally
- [x] `make test` still passes locally
- [ ] CI passes on all Go versions in the matrix
- [ ] CI fails on a deliberate vet violation (verified indirectly — the step runs `go vet ./...` and CI fails if exit code is non-zero)

Closes #16