### PR TITLE
Add install smoke tests and release verification docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 
 # Sentire
 sentire
+
+# GoReleaser snapshot output
+dist/

--- a/.opencode/agent/new-release.md
+++ b/.opencode/agent/new-release.md
@@ -4,7 +4,10 @@ mode: subagent
 ---
 
 When asked to create a new release, you need to:
-- Make sure `make test` passes without errors
+- Make sure `make test` passes without errors (this also runs the
+  `go install` smoke test via `TestGoInstallSmoke`)
+- If `goreleaser` is installed locally, also run `make smoke-release` to
+  verify the release artifacts build and the unpacked binary works
 - Use the provided version number or
   Bump the version number in internal/version/version.go:
   if you find `const Version = "0.1.0"` change to `const Version = "0.1.1"`
@@ -13,3 +16,6 @@ When asked to create a new release, you need to:
 - git push the changes you just did
 - do `git tag v<version>` (use the version you just bumped to in the `internal/version/version.go`)
 - do `git push origin v<version>`
+- After the GitHub `Release` workflow finishes, run the post-release
+  verification checklist in `docs/releases.md` (GitHub artifact, `go install`,
+  and Homebrew)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sentire will be documented in this file.
 - Contributor and agent guidance for keeping `CHANGELOG.md` updated, plus a PR template prompting for an `[Unreleased]` entry
 - `docs/workflows.md` with recipe-style triage, inspection, and reporting workflows plus a troubleshooting checklist for auth, permissions, filters, and empty results
 - `Ctrl+C` (SIGINT) and SIGTERM cancel in-flight API requests, reported with a `canceled` error code
+- `docs/releases.md` with the release pipeline overview and a post-release verification checklist for `go install`, GitHub artifacts, and the Homebrew tap
 
 ### Changed
 - Request timeouts surface a clear `timeout` error code instead of a generic transport failure
@@ -27,6 +28,7 @@ All notable changes to Sentire will be documented in this file.
 - Lower `go.mod` minimum to Go 1.24 and add Go 1.24/1.25 to the CI build matrix
 - API requests use context-aware HTTP request creation, propagating cancellation and deadlines from CLI commands into the client
 - Add `make vet` target and CI step running `go vet ./...`
+- Add install smoke tests: `TestGoInstallSmoke` (runs by default) verifies the public `go install` path, and `make smoke-release` runs an opt-in goreleaser snapshot smoke test against the unpacked archive
 
 ## [0.3.0] - 2026-03-07
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean install help vet
+.PHONY: build test clean install help vet smoke-install smoke-release
 
 # Default target
 all: build
@@ -63,6 +63,16 @@ install: build
 	@echo "Installing sentire..."
 	@cp sentire $(GOPATH)/bin/
 
+# Run the `go install` smoke test (mirrors the public install path)
+smoke-install:
+	@echo "Running go install smoke test..."
+	@go test ./tests/ -run TestGoInstallSmoke -v -count=1
+
+# Run the goreleaser snapshot smoke test (requires goreleaser locally)
+smoke-release:
+	@echo "Running release artifact smoke test..."
+	@SENTIRE_SMOKE_RELEASE=1 go test ./tests/ -run TestGoreleaserSnapshotSmoke -v -count=1 -timeout 10m
+
 # Cross-compile for multiple platforms
 build-all:
 	@echo "Building for multiple platforms..."
@@ -85,4 +95,6 @@ help:
 	@echo "  vet           - Run go vet static analysis"
 	@echo "  lint          - Lint code (requires golangci-lint)"
 	@echo "  install       - Install binary to GOPATH/bin"
+	@echo "  smoke-install - Run go install smoke test against the local module"
+	@echo "  smoke-release - Build a goreleaser snapshot and smoke-test the archive (requires goreleaser)"
 	@echo "  help          - Show this help message"

--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ To bypass the hook temporarily (not recommended):
 git commit --no-verify
 ```
 
+## Releases
+
+See [`docs/releases.md`](docs/releases.md) for the release pipeline overview
+and the post-release verification checklist for `go install`, the GitHub
+release artifacts, and the Homebrew tap.
+
 ## Changelog
 
 User-visible changes are tracked in [`CHANGELOG.md`](CHANGELOG.md). When you

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,101 @@
+# Releasing Sentire
+
+This guide covers the steps to cut a new release and the verification you
+should perform on each public install path before announcing the version.
+
+The release pipeline itself is automated: pushing a tag matching `v*` to
+GitHub triggers the `Release` workflow, which runs the test suite and then
+invokes [GoReleaser](https://goreleaser.com) (see `.goreleaser.yaml`) to
+build cross-platform archives, publish them to the GitHub release page, and
+update the [Homebrew tap](https://github.com/andreagrandi/homebrew-tap).
+
+For the version-bump and tagging workflow itself, see
+`.opencode/agent/new-release.md`.
+
+## Pre-release smoke tests
+
+Before tagging, run the local smoke tests. Neither requires Sentry
+credentials.
+
+```bash
+# Verifies the public `go install` path against the local module.
+make smoke-install
+
+# Builds a full goreleaser snapshot, extracts the current OS/arch archive,
+# and runs `sentire version` and `sentire --help` against the unpacked
+# binary. Requires goreleaser to be installed locally (`brew install
+# goreleaser`).
+make smoke-release
+```
+
+`make smoke-install` runs as part of normal development (it is included in
+`make test` via `TestGoInstallSmoke`). `make smoke-release` is opt-in
+because a full snapshot build cross-compiles for every supported platform
+and adds noticeable time; it is also skipped automatically when goreleaser
+is not on PATH, so it does not break CI environments that lack it.
+
+## Post-release verification
+
+After the `Release` workflow finishes, verify each advertised install path
+end to end. Replace `<version>` with the tag you just pushed (without the
+leading `v` for `go install` queries; with it for the GitHub release page).
+
+### 1. GitHub release artifacts
+
+1. Open the release page:
+   <https://github.com/andreagrandi/sentire/releases/tag/v\<version\>>
+2. Confirm archives for `Darwin_x86_64`, `Darwin_arm64`, `Linux_x86_64`,
+   `Linux_arm64`, and `Windows_x86_64` are attached, along with
+   `checksums.txt`.
+3. Download the archive for your platform, extract it, and run:
+
+   ```bash
+   ./sentire version    # should print "sentire version <version>"
+   ./sentire --help     # should print top-level usage
+   ```
+
+### 2. `go install`
+
+In a clean shell (no `SENTRY_API_TOKEN` set), run:
+
+```bash
+GOBIN="$(mktemp -d)"
+export GOBIN
+go install github.com/andreagrandi/sentire/cmd/sentire@v<version>
+"$GOBIN/sentire" version    # should report v<version>
+"$GOBIN/sentire" --help
+```
+
+If `go install @latest` should also resolve to the new tag, run the same
+check with `@latest`.
+
+### 3. Homebrew
+
+The release workflow pushes an updated formula to
+`andreagrandi/homebrew-tap`. After the workflow finishes, verify the tap
+end to end:
+
+```bash
+brew update
+brew install andreagrandi/tap/sentire   # or `brew upgrade ...` if installed
+sentire version    # should report the new version
+sentire --help
+```
+
+If the formula has not yet been updated, the workflow log under
+`Release → goreleaser` will show the push to the tap repository — check
+both this repo's Actions tab and the tap repo's commit history.
+
+## Troubleshooting
+
+- **`go install` returns an older version.** Module proxies cache versions;
+  `GOPROXY=direct go install github.com/andreagrandi/sentire/cmd/sentire@v<version>`
+  forces a fresh fetch from GitHub.
+- **`brew install` reports "no such formula".** The tap may not be tapped
+  yet. Run `brew tap andreagrandi/tap` first, or use the fully qualified
+  formula name `andreagrandi/tap/sentire`.
+- **`sentire version` reports `unknown` or a stale version.** The release
+  archives are built with ldflags that inject the version
+  (`internal/version.Version`). If the value is wrong, the goreleaser
+  config drifted — check `.goreleaser.yaml` and the most recent commit on
+  the tag.

--- a/tests/install_smoke_test.go
+++ b/tests/install_smoke_test.go
@@ -1,0 +1,209 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestGoInstallSmoke installs the sentire main package via `go install` into a
+// temporary GOBIN and then exercises `sentire version` and `sentire --help`.
+// This mirrors the public install path advertised in the README
+// (`go install github.com/andreagrandi/sentire/cmd/sentire@latest`) without
+// pulling from VCS or requiring Sentry credentials.
+func TestGoInstallSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping go install smoke test in short mode")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	moduleRoot := filepath.Dir(wd)
+
+	gobin := t.TempDir()
+	gocache := t.TempDir()
+
+	install := exec.Command("go", "install", "github.com/andreagrandi/sentire/cmd/sentire")
+	install.Dir = moduleRoot
+	install.Env = append(os.Environ(),
+		"GOBIN="+gobin,
+		"GOCACHE="+gocache,
+		"GOFLAGS=-mod=mod",
+	)
+	var installErr bytes.Buffer
+	install.Stderr = &installErr
+	if err := install.Run(); err != nil {
+		t.Fatalf("go install failed: %v\nstderr: %s", err, installErr.String())
+	}
+
+	binary := filepath.Join(gobin, "sentire")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("expected sentire binary at %s: %v", binary, err)
+	}
+
+	assertSmokeBinary(t, binary)
+}
+
+// assertSmokeBinary runs `version` and `--help` on the given binary and checks
+// that both succeed and produce the expected user-facing output. It is shared
+// with the release-artifact smoke test so both code paths agree on what a
+// working install looks like.
+func assertSmokeBinary(t *testing.T, binary string) {
+	t.Helper()
+
+	versionOut, err := exec.Command(binary, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("sentire version failed: %v\noutput: %s", err, versionOut)
+	}
+	if !strings.Contains(string(versionOut), "sentire version") {
+		t.Errorf("sentire version output missing expected prefix:\n%s", versionOut)
+	}
+
+	helpOut, err := exec.Command(binary, "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("sentire --help failed: %v\noutput: %s", err, helpOut)
+	}
+	help := string(helpOut)
+	if !strings.Contains(help, "Usage:") {
+		t.Errorf("sentire --help output missing 'Usage:':\n%s", help)
+	}
+	if !strings.Contains(help, "sentire") {
+		t.Errorf("sentire --help output missing program name:\n%s", help)
+	}
+}
+
+// TestGoreleaserSnapshotSmoke builds the release artifacts via
+// `goreleaser release --snapshot`, then unpacks the archive for the current
+// OS/arch and runs the standard smoke checks on the extracted binary.
+//
+// The test is opt-in (set SENTIRE_SMOKE_RELEASE=1) because a full snapshot
+// build cross-compiles for every platform and adds ~30s+ to the suite. The
+// Makefile target `make smoke-release` flips the gate.
+func TestGoreleaserSnapshotSmoke(t *testing.T) {
+	if os.Getenv("SENTIRE_SMOKE_RELEASE") == "" {
+		t.Skip("set SENTIRE_SMOKE_RELEASE=1 to run release artifact smoke test (or use `make smoke-release`)")
+	}
+	if _, err := exec.LookPath("goreleaser"); err != nil {
+		t.Skip("goreleaser not installed; skipping release artifact smoke test")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	moduleRoot := filepath.Dir(wd)
+	distDir := filepath.Join(moduleRoot, "dist")
+
+	_ = os.RemoveAll(distDir)
+	t.Cleanup(func() { _ = os.RemoveAll(distDir) })
+
+	build := exec.Command(
+		"goreleaser", "release",
+		"--snapshot", "--clean",
+		"--skip=publish,announce,validate,homebrew,before",
+		"--timeout=10m",
+	)
+	build.Dir = moduleRoot
+	var buildOut bytes.Buffer
+	build.Stdout = &buildOut
+	build.Stderr = &buildOut
+	if err := build.Run(); err != nil {
+		t.Fatalf("goreleaser snapshot failed: %v\noutput:\n%s", err, buildOut.String())
+	}
+
+	archive := findReleaseArchive(t, distDir)
+	binary := extractSentireBinary(t, archive)
+	assertSmokeBinary(t, binary)
+}
+
+// findReleaseArchive returns the archive path for the current OS/arch produced
+// by `goreleaser release --snapshot`. The name template lives in
+// .goreleaser.yaml and follows `sentire_<Os>_<Arch>.<ext>`.
+func findReleaseArchive(t *testing.T, distDir string) string {
+	t.Helper()
+
+	osName := goreleaserOSName(runtime.GOOS)
+	arch := goreleaserArchName(runtime.GOARCH)
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+
+	pattern := filepath.Join(distDir, fmt.Sprintf("sentire_%s_%s.%s", osName, arch, ext))
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s failed: %v", pattern, err)
+	}
+	if len(matches) == 0 {
+		entries, _ := os.ReadDir(distDir)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("no archive matched %s; dist contents: %v", pattern, names)
+	}
+	return matches[0]
+}
+
+// extractSentireBinary extracts the sentire binary from a goreleaser archive
+// into a temp directory and returns its path.
+func extractSentireBinary(t *testing.T, archive string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	var extract *exec.Cmd
+	if strings.HasSuffix(archive, ".zip") {
+		extract = exec.Command("unzip", "-o", archive, "-d", dir)
+	} else {
+		extract = exec.Command("tar", "-xzf", archive, "-C", dir)
+	}
+	if out, err := extract.CombinedOutput(); err != nil {
+		t.Fatalf("failed to extract %s: %v\noutput: %s", archive, err, out)
+	}
+
+	binary := filepath.Join(dir, "sentire")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("expected sentire binary in extracted archive at %s: %v", binary, err)
+	}
+	return binary
+}
+
+func goreleaserOSName(goos string) string {
+	switch goos {
+	case "darwin":
+		return "Darwin"
+	case "linux":
+		return "Linux"
+	case "windows":
+		return "Windows"
+	default:
+		if goos == "" {
+			return goos
+		}
+		return strings.ToUpper(goos[:1]) + goos[1:]
+	}
+}
+
+func goreleaserArchName(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "x86_64"
+	case "386":
+		return "i386"
+	default:
+		return goarch
+	}
+}


### PR DESCRIPTION
## Summary

Adds smoke tests for the public install paths and documents the post-release verification steps. Closes #24.

## Changes

- **`tests/install_smoke_test.go`** (new)
  - `TestGoInstallSmoke` runs `go install github.com/andreagrandi/sentire/cmd/sentire` into a temporary `GOBIN`, then runs `sentire version` and `sentire --help` against the installed binary. Mirrors the README's `go install` path. Runs as part of `make test`.
  - `TestGoreleaserSnapshotSmoke` is opt-in via `SENTIRE_SMOKE_RELEASE=1`: it builds a full `goreleaser release --snapshot`, unpacks the current OS/arch archive, and runs the same smoke checks on the extracted binary. Skips cleanly when goreleaser isn't installed, so it never breaks CI environments that lack it.
  - Neither test requires Sentry credentials (`version`/`--help` short-circuit before token validation).
- **`Makefile`** — `make smoke-install` and `make smoke-release` targets plus help entries.
- **`docs/releases.md`** (new) — release pipeline overview and a post-release verification checklist for `go install`, GitHub release artifacts, and the Homebrew tap, with a troubleshooting section.
- **`.opencode/agent/new-release.md`** — release agent now runs the smoke tests and follows the post-release checklist.
- **`README.md`** — new "Releases" section linking the docs.
- **`CHANGELOG.md`** — `[Unreleased]` entries under Added (docs) and Technical (smoke tests).
- **`.gitignore`** — ignores `dist/` (goreleaser snapshot output).

## Acceptance criteria

- [x] Public install paths are tested (`go install`, release artifacts) or documented as manual checks (Homebrew).
- [x] Smoke tests do not require real Sentry credentials.
- [x] Release docs include the expected verification steps.

## Testing

- `make test` — passes; `TestGoInstallSmoke` runs, `TestGoreleaserSnapshotSmoke` skips (gate not set).
- `make smoke-release` — passes locally with goreleaser installed.
- `make vet` and `gofmt -s -l .` — clean.